### PR TITLE
feat: personalization retention loop (Phase 1-2)

### DIFF
--- a/backend/internal/service/insight/personalization.go
+++ b/backend/internal/service/insight/personalization.go
@@ -1,0 +1,197 @@
+package insight
+
+import (
+	"strings"
+
+	"github.com/nyasha-hama/burnout-predictor-api/internal/score"
+)
+
+type RecommendationState string
+
+const (
+	RecommendationStateGeneric   RecommendationState = "generic"
+	RecommendationStateObserved  RecommendationState = "observed"
+	RecommendationStateEmerging  RecommendationState = "emerging"
+	RecommendationStateConfirmed RecommendationState = "confirmed"
+)
+
+type PersonalizationKind string
+
+const (
+	PersonalizationKindTrigger    PersonalizationKind = "trigger"
+	PersonalizationKindRecovery   PersonalizationKind = "recovery"
+	PersonalizationKindExperiment PersonalizationKind = "experiment"
+)
+
+type RecommendationBasis struct {
+	Kind          PersonalizationKind `json:"kind"`
+	State         RecommendationState `json:"state"`
+	Summary       string              `json:"summary"`
+	EvidenceCount int                 `json:"evidence_count"`
+}
+
+type BriefingChange struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+type PersonalizationProgress struct {
+	ConfirmedTriggers       int    `json:"confirmed_triggers"`
+	ConfirmedRecoveryLevers int    `json:"confirmed_recovery_levers"`
+	Experiments             int    `json:"experiments"`
+	ConfidenceTrend         string `json:"confidence_trend"`
+}
+
+type PlaybookItem struct {
+	Key           string              `json:"key"`
+	Title         string              `json:"title"`
+	Detail        string              `json:"detail"`
+	Kind          PersonalizationKind `json:"kind"`
+	State         RecommendationState `json:"state"`
+	EvidenceCount int                 `json:"evidence_count"`
+	LastSeenDate  string              `json:"last_seen_date"`
+	Trend         string              `json:"trend"`
+}
+
+type PlaybookSections struct {
+	ConfirmedTriggers       []PlaybookItem `json:"confirmed_triggers"`
+	ConfirmedRecoveryLevers []PlaybookItem `json:"confirmed_recovery_levers"`
+	Experiments             []PlaybookItem `json:"experiments"`
+}
+
+type PersonalizationView struct {
+	Progress            PersonalizationProgress `json:"progress"`
+	RecommendationBasis *RecommendationBasis    `json:"recommendation_basis,omitempty"`
+	Playbook            PlaybookSections        `json:"playbook"`
+}
+
+func BuildBriefingChange(currentKey, previousKey, body string) *BriefingChange {
+	if currentKey == "" || currentKey == previousKey || body == "" {
+		return nil
+	}
+	return &BriefingChange{
+		Title: "New today",
+		Body:  body,
+	}
+}
+
+func BuildPersonalizationView(
+	patternInsights []score.PatternInsight,
+	recoveryFeedback []score.RecoveryFeedback,
+	whatWorkedToday *WhatWorkedToday,
+	checkInCount int64,
+	lastSeenDate string,
+) PersonalizationView {
+	view := PersonalizationView{
+		Progress: PersonalizationProgress{ConfidenceTrend: "flat"},
+		Playbook: PlaybookSections{
+			ConfirmedTriggers:       []PlaybookItem{},
+			ConfirmedRecoveryLevers: []PlaybookItem{},
+			Experiments:             []PlaybookItem{},
+		},
+	}
+
+	if checkInCount < 3 {
+		view.RecommendationBasis = &RecommendationBasis{
+			Kind:          PersonalizationKindExperiment,
+			State:         RecommendationStateGeneric,
+			Summary:       "We are still collecting enough check-ins to make this recommendation personal.",
+			EvidenceCount: int(checkInCount),
+		}
+		return view
+	}
+
+	for _, p := range patternInsights {
+		state := RecommendationStateObserved
+		if p.Confidence == "medium" {
+			state = RecommendationStateEmerging
+		}
+		if p.Confidence == "high" {
+			state = RecommendationStateConfirmed
+		}
+		item := PlaybookItem{
+			Key:           p.Driver,
+			Title:         p.Title,
+			Detail:        p.Explanation,
+			Kind:          PersonalizationKindTrigger,
+			State:         state,
+			EvidenceCount: extractEvidenceCount(p.Evidence),
+			LastSeenDate:  lastSeenDate,
+			Trend:         "stable",
+		}
+		if state == RecommendationStateConfirmed {
+			view.Playbook.ConfirmedTriggers = append(view.Playbook.ConfirmedTriggers, item)
+			view.Progress.ConfirmedTriggers++
+		} else {
+			item.Kind = PersonalizationKindExperiment
+			view.Playbook.Experiments = append(view.Playbook.Experiments, item)
+			view.Progress.Experiments++
+		}
+	}
+
+	for _, r := range recoveryFeedback {
+		state := RecommendationStateObserved
+		if r.Confidence == "medium" {
+			state = RecommendationStateEmerging
+		}
+		if r.Confidence == "high" {
+			state = RecommendationStateConfirmed
+		}
+		item := PlaybookItem{
+			Key:           r.Driver,
+			Title:         r.Title,
+			Detail:        r.Explanation,
+			Kind:          PersonalizationKindRecovery,
+			State:         state,
+			EvidenceCount: extractEvidenceCount(r.Evidence),
+			LastSeenDate:  lastSeenDate,
+			Trend:         "stable",
+		}
+		if state == RecommendationStateConfirmed {
+			view.Playbook.ConfirmedRecoveryLevers = append(view.Playbook.ConfirmedRecoveryLevers, item)
+			view.Progress.ConfirmedRecoveryLevers++
+		} else {
+			item.Kind = PersonalizationKindExperiment
+			view.Playbook.Experiments = append(view.Playbook.Experiments, item)
+			view.Progress.Experiments++
+		}
+	}
+
+	if len(view.Playbook.ConfirmedTriggers) > 0 {
+		top := view.Playbook.ConfirmedTriggers[0]
+		view.RecommendationBasis = &RecommendationBasis{
+			Kind:          PersonalizationKindTrigger,
+			State:         RecommendationStateConfirmed,
+			Summary:       top.Detail,
+			EvidenceCount: top.EvidenceCount,
+		}
+	} else if len(view.Playbook.Experiments) > 0 {
+		top := view.Playbook.Experiments[0]
+		view.RecommendationBasis = &RecommendationBasis{
+			Kind:          top.Kind,
+			State:         top.State,
+			Summary:       top.Detail,
+			EvidenceCount: top.EvidenceCount,
+		}
+	}
+
+	if whatWorkedToday != nil {
+		view.Progress.ConfidenceTrend = "up"
+	}
+	if view.Progress.ConfirmedTriggers == 0 && view.Progress.ConfirmedRecoveryLevers == 0 {
+		view.Progress.ConfidenceTrend = "calibrating"
+	}
+
+	return view
+}
+
+func extractEvidenceCount(s string) int {
+	fields := strings.Fields(s)
+	for _, field := range fields {
+		switch field {
+		case "1", "2", "3", "4", "5", "6", "7", "8", "9":
+			return int(field[0] - '0')
+		}
+	}
+	return 1
+}

--- a/backend/internal/service/insight/personalization_test.go
+++ b/backend/internal/service/insight/personalization_test.go
@@ -1,0 +1,78 @@
+package insight
+
+import (
+	"testing"
+
+	"github.com/nyasha-hama/burnout-predictor-api/internal/score"
+)
+
+func TestBuildPersonalizationView_GenericWhenHistoryIsThin(t *testing.T) {
+	view := BuildPersonalizationView([]score.PatternInsight{}, []score.RecoveryFeedback{}, nil, 2, "")
+
+	if view.RecommendationBasis == nil {
+		t.Fatalf("RecommendationBasis = nil, want generic basis")
+	}
+	if view.RecommendationBasis.State != RecommendationStateGeneric {
+		t.Fatalf("state = %q, want %q", view.RecommendationBasis.State, RecommendationStateGeneric)
+	}
+	if view.Progress.ConfirmedTriggers != 0 {
+		t.Fatalf("ConfirmedTriggers = %d, want 0", view.Progress.ConfirmedTriggers)
+	}
+}
+
+func TestBuildPersonalizationView_BucketsTriggersAndRecoveryLevers(t *testing.T) {
+	view := BuildPersonalizationView(
+		[]score.PatternInsight{
+			{
+				Title:       "Back-to-back meeting mornings",
+				Explanation: "Your next-day strain rises after stacked morning meetings.",
+				Evidence:    "4 matching check-ins",
+				Driver:      "meetings",
+				Confidence:  "high",
+			},
+			{
+				Title:       "Deadline-heavy Tuesdays",
+				Explanation: "This may matter, but the evidence is still thin.",
+				Evidence:    "1 matching check-in",
+				Driver:      "deadline",
+				Confidence:  "low",
+			},
+		},
+		[]score.RecoveryFeedback{
+			{
+				Title:              "Early shutdown",
+				Explanation:        "Leaving work on time lowers your next-day strain.",
+				Evidence:           "3 improvements",
+				Driver:             "shutdown",
+				Confidence:         "high",
+				AverageImprovement: 6,
+			},
+		},
+		nil,
+		14,
+		"",
+	)
+
+	if view.Progress.ConfirmedTriggers != 1 {
+		t.Fatalf("ConfirmedTriggers = %d, want 1", view.Progress.ConfirmedTriggers)
+	}
+	if len(view.Playbook.ConfirmedRecoveryLevers) != 1 {
+		t.Fatalf("ConfirmedRecoveryLevers = %d, want 1", len(view.Playbook.ConfirmedRecoveryLevers))
+	}
+	if len(view.Playbook.Experiments) != 1 {
+		t.Fatalf("Experiments = %d, want 1", len(view.Playbook.Experiments))
+	}
+	if view.RecommendationBasis == nil || view.RecommendationBasis.State != RecommendationStateConfirmed {
+		t.Fatalf("RecommendationBasis = %#v, want confirmed trigger basis", view.RecommendationBasis)
+	}
+}
+
+func TestBuildBriefingChange_PrefersNewKey(t *testing.T) {
+	change := BuildBriefingChange("trigger:meetings", "trigger:sleep", "Meetings replaced sleep loss as your strongest trigger.")
+	if change == nil {
+		t.Fatalf("change = nil, want briefing change")
+	}
+	if change.Title != "New today" {
+		t.Fatalf("title = %q, want %q", change.Title, "New today")
+	}
+}

--- a/backend/internal/service/insight/service.go
+++ b/backend/internal/service/insight/service.go
@@ -62,23 +62,27 @@ type WhatWorkedToday struct {
 
 // InsightBundle is the complete insight response — handler calls respond.JSON on it directly.
 type InsightBundle struct {
-	SessionContext      *score.SessionContext             `json:"session_context"`
-	Patterns            []string                          `json:"patterns"`
-	PatternInsights     []score.PatternInsight            `json:"pattern_insights"`
-	EarnedPattern       *score.EarnedPatternInsightResult `json:"earned_pattern"`
-	Signature           *score.SignatureData              `json:"signature"`
-	SignatureNarrative  string                            `json:"signature_narrative"`
-	ArcNarrative        string                            `json:"arc_narrative"`
-	MonthlyArc          *score.MonthlyArcResult           `json:"monthly_arc"`
-	WhatWorks           string                            `json:"what_works"`
-	RecoveryFeedback    []score.RecoveryFeedback          `json:"recovery_feedback"`
-	Milestone           *score.MilestoneData              `json:"milestone"`
-	CheckInCount        int64                             `json:"check_in_count"`
-	AccuracyLabel       string                            `json:"accuracy_label"`
-	DismissedComponents []string                          `json:"dismissed_components"`
-	StreakMilestones    []StreakMilestone                 `json:"streak_milestones"`
-	StreakForgiven      bool                              `json:"streak_forgiven"`
-	WhatWorkedToday     *WhatWorkedToday                  `json:"what_worked_today,omitempty"`
+	SessionContext          *score.SessionContext             `json:"session_context"`
+	Patterns                []string                          `json:"patterns"`
+	PatternInsights         []score.PatternInsight            `json:"pattern_insights"`
+	EarnedPattern           *score.EarnedPatternInsightResult `json:"earned_pattern"`
+	Signature               *score.SignatureData              `json:"signature"`
+	SignatureNarrative      string                            `json:"signature_narrative"`
+	ArcNarrative            string                            `json:"arc_narrative"`
+	MonthlyArc              *score.MonthlyArcResult           `json:"monthly_arc"`
+	WhatWorks               string                            `json:"what_works"`
+	RecoveryFeedback        []score.RecoveryFeedback          `json:"recovery_feedback"`
+	Milestone               *score.MilestoneData              `json:"milestone"`
+	CheckInCount            int64                             `json:"check_in_count"`
+	AccuracyLabel           string                            `json:"accuracy_label"`
+	DismissedComponents     []string                          `json:"dismissed_components"`
+	StreakMilestones        []StreakMilestone                 `json:"streak_milestones"`
+	StreakForgiven          bool                              `json:"streak_forgiven"`
+	WhatWorkedToday         *WhatWorkedToday                  `json:"what_worked_today,omitempty"`
+	PersonalizationProgress PersonalizationProgress           `json:"personalization_progress"`
+	RecommendationBasis     *RecommendationBasis              `json:"recommendation_basis,omitempty"`
+	BriefingChange          *BriefingChange                   `json:"briefing_change,omitempty"`
+	Playbook                PlaybookSections                  `json:"playbook"`
 }
 
 // ── Public methods ────────────────────────────────────────────────────────────
@@ -207,24 +211,58 @@ func (s *Service) Get(ctx context.Context, user db.User) (InsightBundle, error) 
 		dismissed = []string{}
 	}
 
+	lastSeenDate := today.Format("2006-01-02")
+	view := BuildPersonalizationView(patternInsights, recoveryFeedback, whatWorkedToday, totalCount, lastSeenDate)
+
+	currentChangeKey := ""
+	currentChangeBody := ""
+	if len(view.Playbook.ConfirmedTriggers) > 0 {
+		currentChangeKey = "trigger:" + view.Playbook.ConfirmedTriggers[0].Key
+		currentChangeBody = view.Playbook.ConfirmedTriggers[0].Detail
+	} else if len(view.Playbook.ConfirmedRecoveryLevers) > 0 {
+		currentChangeKey = "recovery:" + view.Playbook.ConfirmedRecoveryLevers[0].Key
+		currentChangeBody = view.Playbook.ConfirmedRecoveryLevers[0].Detail
+	}
+
+	previousChangeKey := ""
+	meta, metaErr := s.store.GetInsightMetadata(ctx, db.GetInsightMetadataParams{
+		UserID: user.ID,
+		Key:    "briefing-change-key",
+	})
+	if metaErr == nil && meta.Value.Valid {
+		previousChangeKey = meta.Value.String
+	}
+	briefingChange := BuildBriefingChange(currentChangeKey, previousChangeKey, currentChangeBody)
+	if currentChangeKey != "" && currentChangeKey != previousChangeKey {
+		_, _ = s.store.SetInsightMetadata(ctx, db.SetInsightMetadataParams{
+			UserID: user.ID,
+			Key:    "briefing-change-key",
+			Value:  pgtype.Text{String: currentChangeKey, Valid: true},
+		})
+	}
+
 	return InsightBundle{
-		SessionContext:      sessionCtx,
-		Patterns:            patterns.Patterns,
-		PatternInsights:     patternInsights,
-		EarnedPattern:       earnedPattern,
-		Signature:           sig,
-		SignatureNarrative:  sigNarrative,
-		ArcNarrative:        arcNarrative,
-		MonthlyArc:          monthlyArc,
-		WhatWorks:           whatWorks,
-		RecoveryFeedback:    recoveryFeedback,
-		Milestone:           milestone,
-		CheckInCount:        totalCount,
-		AccuracyLabel:       score.AccuracyLabel(int(totalCount)),
-		DismissedComponents: dismissed,
-		StreakMilestones:    streakMilestones,
-		StreakForgiven:      streakForgiven,
-		WhatWorkedToday:     whatWorkedToday,
+		SessionContext:          sessionCtx,
+		Patterns:                patterns.Patterns,
+		PatternInsights:         patternInsights,
+		EarnedPattern:           earnedPattern,
+		Signature:               sig,
+		SignatureNarrative:      sigNarrative,
+		ArcNarrative:            arcNarrative,
+		MonthlyArc:              monthlyArc,
+		WhatWorks:               whatWorks,
+		RecoveryFeedback:        recoveryFeedback,
+		Milestone:               milestone,
+		CheckInCount:            totalCount,
+		AccuracyLabel:           score.AccuracyLabel(int(totalCount)),
+		DismissedComponents:     dismissed,
+		StreakMilestones:        streakMilestones,
+		StreakForgiven:          streakForgiven,
+		WhatWorkedToday:         whatWorkedToday,
+		PersonalizationProgress: view.Progress,
+		RecommendationBasis:     view.RecommendationBasis,
+		BriefingChange:          briefingChange,
+		Playbook:                view.Playbook,
 	}, nil
 }
 

--- a/docs/superpowers/specs/2026-04-16-personalization-retention-design.md
+++ b/docs/superpowers/specs/2026-04-16-personalization-retention-design.md
@@ -1,0 +1,367 @@
+# Personalization Retention Loop — Daily Briefing and Playbook
+
+**Date:** 2026-04-16  
+**Status:** Ready for review
+
+## Problem
+
+Overload has crossed the line from a simple score dashboard into a coaching product. The app already has the right raw pieces: daily check-in, action plan, next-day feedback, pattern insights, consistency, and streak mechanics. The problem is that these pieces feel like adjacent widgets rather than one accumulating intelligence system.
+
+That weakens retention. A user can understand that the app is useful without feeling compelled to open it every day. The current dashboard answers many questions, but it does not clearly answer the one that matters for daily habit formation:
+
+> "What is new about what Overload understands about me today?"
+
+The next product step is not "add more insight cards." It is to make personalization itself the product.
+
+## Goal
+
+Create a daily-open habit where users return to Overload because they expect a fresh personal briefing and visible proof that the system understands their triggers and recovery levers better than it did yesterday.
+
+The daily emotional reward is not streak guilt, raw score checking, or generic wellness encouragement. It is:
+
+> "Overload gets sharper about me every day."
+
+## Product Principles
+
+1. The top of the dashboard must feel like a briefing, not a collection of cards.
+2. Recommendations must declare why they are personal and how trustworthy they are.
+3. Insights must accumulate into durable memory, not disappear as a feed.
+4. Feedback loops must be lightweight. The app should feel helpful, not like homework.
+5. The product should prefer visible learning over visible complexity.
+
+## Non-Goals
+
+This design does not attempt to solve:
+
+- team or manager workflows
+- pricing or upgrade flow redesign
+- new data integrations such as calendar sync expansion
+- push notification infrastructure
+- a new scoring model from scratch
+
+Those may matter later, but they are not the right lever for the next retention push.
+
+## Design Summary
+
+The product shifts to a four-layer loop:
+
+1. **Today’s Briefing**
+   The primary dashboard surface that tells the user what to do, why, and what the system has newly learned.
+2. **Personalization Progress**
+   A visible model of how much of the system is generic, emerging, and confirmed.
+3. **Your Playbook**
+   A durable memory layer that stores confirmed triggers, recovery levers, and experiments in progress.
+4. **Feedback Loop**
+   A minimal outcome loop that lets the app upgrade or downgrade confidence in its advice over time.
+
+The result should feel less like "burnout analytics" and more like a personal operating manual that updates daily.
+
+## 1. Today’s Briefing
+
+The top of the main dashboard should become a single dominant surface called `Today’s Briefing`.
+
+It must answer four questions in this order:
+
+1. What should I do today?
+2. Why is that personal to me?
+3. How sure is Overload about this advice now?
+4. What changed in what the system knows since yesterday?
+
+### Briefing Structure
+
+The briefing should contain four stacked sub-sections:
+
+- **Primary move**
+  One recommended action for today. This is the headline.
+- **Why this is showing up**
+  The most important driver behind the recommendation, expressed in plain language.
+- **Confidence**
+  A short statement that tells the user whether this is generic guidance, emerging personalization, or confirmed personalization.
+- **New learning**
+  One concise line about what changed since the user’s last meaningful interaction.
+
+### Example states
+
+**Low-data user**
+- Primary move: "Protect your first focus block tomorrow."
+- Why: "Your score is elevated and your recent notes mention deadline pressure."
+- Confidence: "Generic for now. We need a few more check-ins before this becomes personal."
+- New learning: "No new patterns confirmed yet."
+
+**Mid-data user**
+- Primary move: "Shut down by 9 PM tonight."
+- Why: "Your strain tends to stay elevated after late work nights."
+- Confidence: "Emerging pattern. We have seen this several times, but we are still testing it."
+- New learning: "Late work is now showing up as a likely trigger."
+
+**High-data user**
+- Primary move: "Protect tomorrow morning from meetings."
+- Why: "Back-to-back meeting mornings are your strongest confirmed trigger."
+- Confidence: "Confirmed personal pattern, based on repeated score increases after stacked meeting blocks."
+- New learning: "Meeting-heavy mornings replaced sleep loss as your strongest trigger this week."
+
+### Information Architecture Impact
+
+This means the dashboard should no longer lead with separate cards for score, action, feedback, and insight. Existing dashboard elements should be reorganized so the first screen read feels like one coherent narrative. Supporting cards should remain, but their role changes from `main answer` to `evidence and drill-down`.
+
+## 2. Personalization Progress
+
+The current calibration framing is technically correct but emotionally weak. It tells the user the system is still learning, but it does not make that learning feel valuable.
+
+Replace the current "Calibration" concept with `Personalization Progress`.
+
+### Core model
+
+Overload should maintain three types of personalization items:
+
+- **Triggers**
+  Conditions that reliably increase strain.
+- **Recovery levers**
+  Actions or conditions that reliably improve next-day outcomes.
+- **Experiments**
+  Suspected patterns that are not yet strong enough to trust.
+
+Each item should move through visible states:
+
+- **Observed**
+  Seen once or twice.
+- **Emerging**
+  Repeating enough to matter, but still not stable.
+- **Confirmed**
+  Strong enough to influence recommendations directly.
+
+### User-facing progress surface
+
+The dashboard should include a compact progress card showing counts such as:
+
+- `2 confirmed triggers`
+- `1 confirmed recovery lever`
+- `3 experiments still in progress`
+- `confidence up from last week`
+
+The app should also explain the status of the current recommendation in the same vocabulary:
+
+- `Based on a confirmed trigger`
+- `Based on an emerging recovery pattern`
+- `Generic for now while we collect more evidence`
+
+This turns "the app is learning" from background system behavior into visible product value.
+
+## 3. Your Playbook
+
+Insights currently surface as momentary UI. That is not enough. The user needs a durable layer that proves the system is building memory.
+
+Introduce a `Your Playbook` surface, initially as a major dashboard section and later as its own dedicated route once it earns enough density.
+
+### Playbook sections
+
+The playbook should be organized into three groups:
+
+- **Confirmed triggers**
+  Patterns that reliably push the user toward higher strain.
+- **Confirmed recovery levers**
+  Patterns or actions that reliably help the user recover.
+- **Experiments in progress**
+  Plausible but unsettled hypotheses.
+
+### Item anatomy
+
+Each playbook item should show:
+
+- the pattern statement
+- current state: observed, emerging, or confirmed
+- evidence count
+- recentness
+- whether confidence is rising, stable, or falling
+
+### Daily relevance
+
+The playbook becomes retention-positive when items change state and the app calls that out explicitly:
+
+- "New today: walking moved from emerging to confirmed."
+- "New today: meetings are now your strongest trigger."
+- "Still testing: early shutdown may help, but we need more evidence."
+
+This is the durable memory layer beneath the daily briefing. The briefing is the day’s answer. The playbook is the growing engine that makes the answer increasingly personal.
+
+## 4. Feedback Loop
+
+The current app already gestures toward a closed loop, but it needs to become explicit.
+
+Every recommendation should have an optional follow-through path:
+
+1. The app recommends one move.
+2. The user can optionally confirm whether they did it.
+3. The next day, the app interprets the outcome.
+4. The app adjusts confidence in the advice and tells the user what it changed.
+
+### Product requirement
+
+The loop must stay lightweight. Users should never be forced into a multi-step questionnaire just to maintain value.
+
+The minimal interaction model is:
+
+- `Did it`
+- `Partly did it`
+- `Didn’t do it`
+
+The next-day read can then say:
+
+- "This move seems to be helping. Confidence increased."
+- "No clear effect yet. Still testing."
+- "This advice may matter less than we thought."
+
+That is the mechanism that upgrades the product from static advice to adaptive coaching.
+
+## 5. Dashboard Reshape
+
+The main dashboard should be restructured in this order:
+
+1. **Today’s Briefing**
+2. **Personalization Progress**
+3. **Your Playbook**
+4. **Supporting evidence**
+   Score details, forecast, recent check-ins, weekly view entry points, and history entry points
+
+### Existing component evolution
+
+Current components should be repurposed as follows:
+
+- [ActionPlan.tsx](/home/nyasha-hama/projects/burnout-predictor/frontend/components/dashboard/ActionPlan.tsx)
+  Becomes part of the briefing, not a sibling card.
+- [NextDayFeedbackCard.tsx](/home/nyasha-hama/projects/burnout-predictor/frontend/components/dashboard/NextDayFeedbackCard.tsx)
+  Becomes the `new learning` or `outcome update` row inside the briefing when relevant.
+- [InsightRevealCard.tsx](/home/nyasha-hama/projects/burnout-predictor/frontend/components/dashboard/InsightRevealCard.tsx)
+  Evolves into the basis of the playbook, not just a dismissable insight feed.
+- The current calibration card in [page.tsx](/home/nyasha-hama/projects/burnout-predictor/frontend/app/dashboard/page.tsx)
+  Becomes `Personalization Progress`.
+- Streak and consistency remain useful, but they should stop carrying the retention story on their own.
+
+## 6. Data and System Model
+
+This design requires a small but explicit personalization model behind the UI.
+
+### Core entities
+
+The product should support these conceptual records:
+
+- `PersonalizationItem`
+  A trigger, recovery lever, or experiment
+- `RecommendationBasis`
+  Why today’s recommendation exists and what evidence tier it came from
+- `BriefingChange`
+  What changed since the last session
+
+### Required attributes
+
+A personalization item should be able to express:
+
+- type: trigger, recovery, experiment
+- state: observed, emerging, confirmed
+- evidence count
+- confidence score or band
+- last seen date
+- recent trend in confidence
+- supporting explanation
+
+### System outputs
+
+The backend should eventually be able to generate:
+
+- the top recommendation for today
+- the strongest reason behind it
+- the confidence explanation
+- the most important newly confirmed or updated learning
+- grouped playbook sections
+
+This is an additive layer on top of the current score and insight system, not a replacement for it.
+
+## 7. Low-Data and Error States
+
+The product must remain useful before the playbook is mature.
+
+### Low-data behavior
+
+If there is not enough personal evidence yet:
+
+- keep the briefing structure intact
+- use generic recommendations
+- explicitly explain what unlocks personalization next
+
+Example:
+
+> "We are still testing what drives your strain. Two more check-ins with notes will unlock your first emerging pattern."
+
+### Ambiguous-data behavior
+
+If evidence conflicts:
+
+- say the app is still testing
+- do not overstate certainty
+- avoid pretending an experiment is confirmed
+
+### Missing-data behavior
+
+If the app cannot produce new learning:
+
+- still show the recommendation
+- show the strongest currently known pattern or a generic fallback
+- avoid blank states where the top of the dashboard feels empty
+
+## 8. Success Criteria
+
+This design succeeds if the user can describe the app this way:
+
+> "I open it because it tells me what matters today and it keeps getting more specific about my patterns."
+
+### Product signals to track
+
+- increase in weekly active users who open without being prompted by a missed check-in flow
+- increase in consecutive days with dashboard opens, not just check-in submissions
+- increase in users who return after a new learning event
+- increase in users who can accumulate confirmed playbook items
+
+### Qualitative benchmark
+
+A user should be able to answer these questions after one week:
+
+- What is my strongest trigger right now?
+- What seems to help me recover?
+- How sure is the app about that?
+- What did it learn recently?
+
+If they cannot, the product still feels like analytics instead of a coach.
+
+## 9. Phased Execution
+
+### Phase 1: Briefing-first dashboard
+
+Reshape the top of the dashboard into one coherent briefing using existing action, insight, and feedback components.
+
+**Outcome:** the daily-open value becomes obvious immediately.
+
+### Phase 2: Personalization Progress
+
+Add explicit learning states and recommendation provenance, then replace calibration with a progress model the user can understand.
+
+**Outcome:** the user sees the system becoming more trustworthy over time.
+
+### Phase 3: Your Playbook
+
+Create the durable memory layer for confirmed triggers, confirmed recovery levers, and experiments in progress.
+
+**Outcome:** transient insights become a growing product asset.
+
+### Phase 4: Outcome loop and retention multiplier
+
+Add minimal follow-through capture, next-day confidence updates, and reminder logic that triggers when there is something new to learn or review.
+
+**Outcome:** Overload becomes a daily operating manual rather than a passive tracker.
+
+## Recommendation
+
+Phase 1 should ship first and stay tightly scoped. It is the fastest way to make the product feel different without waiting for a larger backend rewrite.
+
+Phases 2 and 3 are the real moat. That is where the app becomes hard to substitute, because it stops being "a score app" and starts becoming a personal system memory.
+
+Phase 4 should come after the product language is already coherent. A stronger reminder system matters, but only once there is something distinctly worth returning for.

--- a/frontend/__tests__/dashboard-page.test.tsx
+++ b/frontend/__tests__/dashboard-page.test.tsx
@@ -29,7 +29,8 @@ const mockDashboardData = {
     follow_up: null,
     streak_forgiven: false,
     streak_milestones: [],
-  } as ScoreCardResult,
+    feedback_submitted_for_today: false,
+  } as unknown as ScoreCardResult,
   checkins: [
     {
       id: "c1",
@@ -82,6 +83,60 @@ const mockDashboardData = {
     },
     streak_milestones: [],
     streak_forgiven: false,
+    personalization_progress: {
+      confirmed_triggers: 1,
+      confirmed_recovery_levers: 1,
+      experiments: 2,
+      confidence_trend: "up",
+    },
+    recommendation_basis: {
+      kind: "trigger",
+      state: "confirmed",
+      summary: "Back-to-back meeting mornings are your strongest trigger.",
+      evidence_count: 4,
+    },
+    briefing_change: {
+      title: "New today",
+      body: "Meetings replaced sleep loss as your strongest trigger.",
+    },
+    playbook: {
+      confirmed_triggers: [
+        {
+          key: "meetings",
+          title: "Back-to-back meeting mornings",
+          detail: "Your next-day score rises after stacked morning meetings.",
+          kind: "trigger",
+          state: "confirmed",
+          evidence_count: 4,
+          last_seen_date: "2026-04-15",
+          trend: "rising",
+        },
+      ],
+      confirmed_recovery_levers: [
+        {
+          key: "shutdown",
+          title: "Early shutdown",
+          detail: "Leaving work on time lowers your next-day strain.",
+          kind: "recovery",
+          state: "confirmed",
+          evidence_count: 3,
+          last_seen_date: "2026-04-14",
+          trend: "stable",
+        },
+      ],
+      experiments: [
+        {
+          key: "deadline",
+          title: "Deadline-heavy Tuesdays",
+          detail: "Still testing whether this is a stable trigger.",
+          kind: "experiment",
+          state: "observed",
+          evidence_count: 1,
+          last_seen_date: "2026-04-09",
+          trend: "new",
+        },
+      ],
+    },
   } as unknown as InsightBundle,
   loadingData: false,
   loadingMessage: "",
@@ -105,6 +160,20 @@ vi.mock("@/contexts/AuthContext", () => ({
   }),
 }));
 
+vi.mock("@/components/dashboard/PersonalizationProgress", () => ({
+  default: () => <div>Personalization Progress</div>,
+}));
+
+vi.mock("@/components/dashboard/PlaybookPanel", () => ({
+  default: ({ title, subtitle }: { title: string; subtitle: string; playbook: unknown }) => (
+    <div>
+      <div>{title}</div>
+      <div>{subtitle}</div>
+      <div>Your Playbook</div>
+    </div>
+  ),
+}));
+
 describe("DashboardPage", () => {
   it("leads with a single briefing surface before the supporting evidence cards", async () => {
     const { default: DashboardPage } = await import("@/app/dashboard/page");
@@ -116,5 +185,7 @@ describe("DashboardPage", () => {
     expect(screen.getByText(/protect tomorrow morning from meetings/i)).toBeInTheDocument();
     expect(screen.getByText(/why this is showing up/i)).toBeInTheDocument();
     expect(screen.getByText(/tomorrow forecast/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/personalization progress/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/your playbook/i).length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/__tests__/dashboard-page.test.tsx
+++ b/frontend/__tests__/dashboard-page.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import type { InsightBundle, ScoreCardResult } from "@/lib/types";
 
 const mockDashboardData = {
   scoreCard: {
@@ -28,7 +29,7 @@ const mockDashboardData = {
     follow_up: null,
     streak_forgiven: false,
     streak_milestones: [],
-  } as any,
+  } as ScoreCardResult,
   checkins: [
     {
       id: "c1",
@@ -81,7 +82,7 @@ const mockDashboardData = {
     },
     streak_milestones: [],
     streak_forgiven: false,
-  } as any,
+  } as unknown as InsightBundle,
   loadingData: false,
   loadingMessage: "",
   loadError: "",

--- a/frontend/__tests__/dashboard-page.test.tsx
+++ b/frontend/__tests__/dashboard-page.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const mockDashboardData = {
+  scoreCard: {
+    score: { score: 61, level: "warning", label: "Watch this", signals: [] },
+    explanation: "Meetings are stacking into tomorrow morning.",
+    suggestion: "Protect tomorrow morning from meetings.",
+    daily_forecast: {
+      score: 64,
+      delta: 3,
+      direction: "up",
+      confidence: "medium",
+      summary: "Tomorrow gets heavier if the calendar stays crowded.",
+    },
+    recommended_action: {
+      title: "Protect tomorrow morning from meetings",
+      detail: "You reliably spike after stacked meeting mornings.",
+      driver: "meetings",
+      confidence: "medium",
+    },
+    trajectory: "Trending up this week",
+    accuracy_label: "Based on 11 real check-ins",
+    streak: 6,
+    has_checkin: true,
+    consistency_pct: 86,
+    has_follow_up: false,
+    follow_up: null,
+    streak_forgiven: false,
+    streak_milestones: [],
+  } as any,
+  checkins: [
+    {
+      id: "c1",
+      user_id: "u1",
+      checked_in_date: "2026-04-16",
+      stress: 4,
+      score: 61,
+      note: "Calendar is overloaded with demos.",
+      role_snapshot: "engineer",
+      sleep_snapshot: 8,
+      meeting_count: 6,
+      ai_recovery_plan: null,
+      ai_generated_at: null,
+      created_at: "2026-04-16T08:00:00Z",
+      updated_at: "2026-04-16T08:00:00Z",
+      energy_level: 2,
+      focus_quality: 2,
+      hours_worked: 9,
+      physical_symptoms: ["fatigue"],
+      small_wins: "blocked a focus hour",
+    },
+  ],
+  insightBundle: {
+    session_context: null,
+    patterns: [],
+    pattern_insights: [
+      {
+        title: "Meeting-heavy mornings are pushing you up",
+        explanation: "Your last few higher scores followed stacked morning meetings.",
+        evidence: "4 matching check-ins",
+        driver: "meetings",
+        confidence: "medium",
+      },
+    ],
+    earned_pattern: null,
+    signature: null,
+    signature_narrative: "",
+    arc_narrative: "",
+    monthly_arc: null,
+    what_works: "Early shutdowns help more than walks.",
+    recovery_feedback: [],
+    milestone: null,
+    check_in_count: 11,
+    accuracy_label: "Based on 11 real check-ins",
+    dismissed_components: [],
+    what_worked_today: {
+      action: "blocked a focus hour",
+      improvement: 7,
+      evidence: "Blocking a focus hour has lowered your next-day score by 7 points on average.",
+    },
+    streak_milestones: [],
+    streak_forgiven: false,
+  } as any,
+  loadingData: false,
+  loadingMessage: "",
+  loadError: "",
+  ready: true,
+  followUp: null,
+  dismissFollowUp: vi.fn(),
+  handleCheckInComplete: vi.fn(),
+  reload: vi.fn(),
+};
+
+vi.mock("@/contexts/DashboardDataContext", () => ({
+  useDashboardData: () => mockDashboardData,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+      user: { id: "u1", email: "test@example.com", name: "Test", timezone: "UTC" },
+      api: { get: vi.fn(), post: vi.fn(), put: vi.fn() },
+      logout: vi.fn(),
+  }),
+}));
+
+describe("DashboardPage", () => {
+  it("leads with a single briefing surface before the supporting evidence cards", async () => {
+    const { default: DashboardPage } = await import("@/app/dashboard/page");
+
+    render(<DashboardPage />);
+
+    expect(screen.getByRole("heading", { name: /today's briefing/i })).toBeInTheDocument();
+    expect(screen.getByText(/what should i do today/i)).toBeInTheDocument();
+    expect(screen.getByText(/protect tomorrow morning from meetings/i)).toBeInTheDocument();
+    expect(screen.getByText(/why this is showing up/i)).toBeInTheDocument();
+    expect(screen.getByText(/tomorrow forecast/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/playbook-panel.test.tsx
+++ b/frontend/__tests__/playbook-panel.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import PlaybookPanel from "@/components/dashboard/PlaybookPanel";
+
+describe("PlaybookPanel", () => {
+  it("renders confirmed triggers, confirmed recovery levers, and experiments", () => {
+    render(
+      <PlaybookPanel
+        title="Your Playbook"
+        subtitle="The durable memory behind today's recommendation."
+        playbook={{
+          confirmed_triggers: [
+            {
+              key: "meetings",
+              title: "Back-to-back meeting mornings",
+              detail: "Your next-day strain rises after stacked morning meetings.",
+              kind: "trigger",
+              state: "confirmed",
+              evidence_count: 4,
+              last_seen_date: "2026-04-15",
+              trend: "rising",
+            },
+          ],
+          confirmed_recovery_levers: [
+            {
+              key: "shutdown",
+              title: "Early shutdown",
+              detail: "Leaving work on time lowers your next-day strain.",
+              kind: "recovery",
+              state: "confirmed",
+              evidence_count: 3,
+              last_seen_date: "2026-04-14",
+              trend: "stable",
+            },
+          ],
+          experiments: [
+            {
+              key: "deadline",
+              title: "Deadline-heavy Tuesdays",
+              detail: "Still testing whether this is a stable trigger.",
+              kind: "experiment",
+              state: "observed",
+              evidence_count: 1,
+              last_seen_date: "2026-04-09",
+              trend: "new",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByText(/confirmed triggers/i)).toBeInTheDocument();
+    expect(screen.getByText(/back-to-back meeting mornings/i)).toBeInTheDocument();
+    expect(screen.getByText(/confirmed recovery levers/i)).toBeInTheDocument();
+    expect(screen.getByText(/early shutdown/i)).toBeInTheDocument();
+    expect(screen.getByText(/experiments in progress/i)).toBeInTheDocument();
+    expect(screen.getByText(/deadline-heavy tuesdays/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,11 +2,10 @@
 
 import { Activity, RefreshCcw, TrendingDown, TrendingUp } from "lucide-react";
 import CheckIn from "@/components/dashboard/CheckIn";
-import ActionPlan from "@/components/dashboard/ActionPlan";
+import TodayBriefing from "@/components/dashboard/TodayBriefing";
 import StreakDots from "@/components/dashboard/StreakDots";
 import StreakMilestoneCard from "@/components/dashboard/StreakMilestoneCard";
 import ConsistencyMetric from "@/components/dashboard/ConsistencyMetric";
-import NextDayFeedbackCard from "@/components/dashboard/NextDayFeedbackCard";
 import InsightRevealCard from "@/components/dashboard/InsightRevealCard";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 import { Button } from "@/components/ui/button";
@@ -85,6 +84,21 @@ export default function DashboardPage() {
   const patternInsights = insightBundle?.pattern_insights ?? [];
   const whatWorks = insightBundle?.what_works ?? "";
 
+  const briefingReason =
+    patternInsights[0]?.explanation ??
+    whatWorks ??
+    scoreCard?.explanation ??
+    "Check in today to start turning repeated patterns into personal guidance.";
+
+  const briefingConfidence = scoreCard?.accuracy_label
+    ? `${scoreCard.accuracy_label}. More check-ins make this recommendation more personal.`
+    : "Generic for now. Add a few more check-ins and notes so Overload can separate real patterns from noise.";
+
+  const briefingNewLearning =
+    whatWorkedToday?.evidence ??
+    patternInsights[0]?.evidence ??
+    "No new patterns confirmed yet. Keep checking in and Overload will turn repeated signals into something personal.";
+
   const trend = recent.length >= 2 ? recent[recent.length - 1].score - recent[0].score : 0;
 
   let dangerStreak = 0;
@@ -154,21 +168,21 @@ export default function DashboardPage() {
 
       <StreakMilestoneCard milestones={streakMilestones} />
 
-      <ActionPlan
-        score={liveScore}
-        trend={trend}
-        dangerStreak={dangerStreak}
-        dangerDaysAhead={0}
-        recoveryDate=""
-        plan={plan}
-        note={todayCheckIn?.note ?? undefined}
-        stress={todayCheckIn?.stress}
-        consecutiveDays={dangerDays}
-        role=""
-        smallWins={todayCheckIn?.small_wins ?? null}
-      />
-
-      <NextDayFeedbackCard whatWorked={whatWorkedToday} />
+      {scoreCard && (
+        <TodayBriefing
+          scoreCard={scoreCard}
+          todayCheckIn={todayCheckIn}
+          plan={plan}
+          trend={trend}
+          dangerStreak={dangerStreak}
+          dangerDaysAhead={0}
+          recoveryDate=""
+          reason={briefingReason}
+          confidenceCopy={briefingConfidence}
+          newLearning={briefingNewLearning}
+          whatWorkedToday={whatWorkedToday}
+        />
+      )}
 
       <InsightRevealCard
         patternInsights={patternInsights}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import StreakDots from "@/components/dashboard/StreakDots";
 import StreakMilestoneCard from "@/components/dashboard/StreakMilestoneCard";
 import ConsistencyMetric from "@/components/dashboard/ConsistencyMetric";
 import InsightRevealCard from "@/components/dashboard/InsightRevealCard";
+import PersonalizationProgress from "@/components/dashboard/PersonalizationProgress";
+import PlaybookPanel from "@/components/dashboard/PlaybookPanel";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -166,22 +168,36 @@ export default function DashboardPage() {
         <CheckIn checkins={checkins} followUp={followUp} onComplete={handleCheckInComplete} onDismissFollowUp={dismissFollowUp} />
       </div>
 
-      <StreakMilestoneCard milestones={streakMilestones} />
+<StreakMilestoneCard milestones={streakMilestones} />
 
       {scoreCard && (
-        <TodayBriefing
-          scoreCard={scoreCard}
-          todayCheckIn={todayCheckIn}
-          plan={plan}
-          trend={trend}
-          dangerStreak={dangerStreak}
-          dangerDaysAhead={0}
-          recoveryDate=""
-          reason={briefingReason}
-          confidenceCopy={briefingConfidence}
-          newLearning={briefingNewLearning}
-          whatWorkedToday={whatWorkedToday}
-        />
+        <>
+          <TodayBriefing
+            scoreCard={scoreCard}
+            todayCheckIn={todayCheckIn}
+            plan={plan}
+            trend={trend}
+            dangerStreak={dangerStreak}
+            dangerDaysAhead={0}
+            recoveryDate=""
+            reason={briefingReason}
+            confidenceCopy={briefingConfidence}
+            newLearning={briefingNewLearning}
+            whatWorkedToday={whatWorkedToday}
+          />
+
+          <PersonalizationProgress
+            progress={insightBundle?.personalization_progress ?? null}
+            accuracyLabel={scoreCard?.accuracy_label ?? "Still learning"}
+          />
+
+          <PlaybookPanel
+            title="Your Playbook"
+            subtitle="The durable memory behind today's recommendation."
+            playbook={insightBundle?.playbook ?? null}
+            compact
+          />
+        </>
       )}
 
       <InsightRevealCard

--- a/frontend/app/dashboard/playbook/page.tsx
+++ b/frontend/app/dashboard/playbook/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import PlaybookPanel from "@/components/dashboard/PlaybookPanel";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
+
+export default function PlaybookPage() {
+  const { insightBundle } = useDashboardData();
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-4xl tracking-tight">Your Playbook</h1>
+        <p className="text-muted-foreground">
+          Confirmed triggers, confirmed recovery levers, and the experiments Overload is still testing.
+        </p>
+      </div>
+
+      <PlaybookPanel
+        title="Your Playbook"
+        subtitle="The durable memory behind today's recommendation."
+        playbook={insightBundle?.playbook ?? null}
+      />
+    </div>
+  );
+}

--- a/frontend/components/dashboard/DashboardShell.tsx
+++ b/frontend/components/dashboard/DashboardShell.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { BarChart3, CalendarDays, LayoutDashboard, LogOut, Settings } from "lucide-react";
+import { BarChart3, BookOpen, CalendarDays, LayoutDashboard, LogOut, Settings } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { DashboardDataProvider, useDashboardData } from "@/contexts/DashboardDataContext";
 import { AppLogo } from "@/components/AppLogo";
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/dashboard/playbook", label: "Playbook", icon: BookOpen },
   { href: "/dashboard/history", label: "History", icon: BarChart3 },
   { href: "/dashboard/weekly", label: "Weekly", icon: CalendarDays },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
@@ -80,7 +81,7 @@ function DashboardShellFrame({ children }: { children: React.ReactNode }) {
 
           <main className="flex-1 px-4 py-6 sm:px-6">{children}</main>
 
-          <nav className="sticky bottom-0 grid grid-cols-4 border-t border-border bg-background p-2 lg:hidden">
+          <nav className="sticky bottom-0 grid grid-cols-5 border-t border-border bg-background p-2 lg:hidden">
             {navItems.map((item) => (
               <Link
                 key={item.href}

--- a/frontend/components/dashboard/PersonalizationProgress.tsx
+++ b/frontend/components/dashboard/PersonalizationProgress.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PersonalizationProgressSummary } from "@/lib/types";
+
+export default function PersonalizationProgress({
+  progress,
+  accuracyLabel,
+}: {
+  progress: PersonalizationProgressSummary | null;
+  accuracyLabel: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Personalization Progress</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4 md:grid-cols-4">
+        <div>
+          <div className="text-sm text-muted-foreground">Confirmed triggers</div>
+          <div className="mt-2 text-3xl font-semibold">{progress?.confirmed_triggers ?? 0}</div>
+        </div>
+        <div>
+          <div className="text-sm text-muted-foreground">Recovery levers</div>
+          <div className="mt-2 text-3xl font-semibold">{progress?.confirmed_recovery_levers ?? 0}</div>
+        </div>
+        <div>
+          <div className="text-sm text-muted-foreground">Experiments</div>
+          <div className="mt-2 text-3xl font-semibold">{progress?.experiments ?? 0}</div>
+        </div>
+        <div>
+          <div className="text-sm text-muted-foreground">Confidence trend</div>
+          <div className="mt-2 flex items-center gap-2">
+            <Badge variant="outline">{progress?.confidence_trend ?? "calibrating"}</Badge>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">{accuracyLabel}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/dashboard/PlaybookPanel.tsx
+++ b/frontend/components/dashboard/PlaybookPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PlaybookSections } from "@/lib/types";
+
+export default function PlaybookPanel({
+  title,
+  subtitle,
+  playbook,
+  compact = false,
+}: {
+  title: string;
+  subtitle: string;
+  playbook: PlaybookSections | null;
+  compact?: boolean;
+}) {
+  const sections = [
+    { heading: "Confirmed triggers", items: playbook?.confirmed_triggers ?? [] },
+    { heading: "Confirmed recovery levers", items: playbook?.confirmed_recovery_levers ?? [] },
+    { heading: "Experiments in progress", items: playbook?.experiments ?? [] },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      </CardHeader>
+      <CardContent className={compact ? "space-y-4" : "grid gap-6 lg:grid-cols-3"}>
+        {sections.map((section) => (
+          <section key={section.heading} className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {section.heading}
+            </h3>
+            <div className="space-y-2">
+              {section.items.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
+                  Nothing here yet.
+                </div>
+              ) : (
+                section.items.map((item) => (
+                  <div key={item.key} className="rounded-lg border border-border/70 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="font-medium">{item.title}</div>
+                      <Badge variant={item.state === "confirmed" ? "secondary" : "outline"}>{item.state}</Badge>
+                    </div>
+                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.detail}</p>
+                    <p className="mt-2 text-xs uppercase tracking-[0.15em] text-muted-foreground">
+                      {item.evidence_count} signals · {item.trend} · last seen {item.last_seen_date}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/dashboard/TodayBriefing.tsx
+++ b/frontend/components/dashboard/TodayBriefing.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import ActionPlan from "@/components/dashboard/ActionPlan";
+import NextDayFeedbackCard from "@/components/dashboard/NextDayFeedbackCard";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CheckIn, PlanSection, ScoreCardResult, WhatWorkedToday } from "@/lib/types";
+
+interface TodayBriefingProps {
+  scoreCard: ScoreCardResult;
+  todayCheckIn: CheckIn | undefined;
+  plan: PlanSection[];
+  trend: number;
+  dangerStreak: number;
+  dangerDaysAhead: number;
+  recoveryDate: string;
+  reason: string;
+  confidenceCopy: string;
+  newLearning: string;
+  whatWorkedToday: WhatWorkedToday | null;
+}
+
+export default function TodayBriefing({
+  scoreCard,
+  todayCheckIn,
+  plan,
+  trend,
+  dangerStreak,
+  dangerDaysAhead,
+  recoveryDate,
+  reason,
+  confidenceCopy,
+  newLearning,
+  whatWorkedToday,
+}: TodayBriefingProps) {
+  return (
+    <Card className="border-primary/15 bg-primary/[0.03]">
+      <CardHeader className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-3xl tracking-tight">Today&apos;s Briefing</CardTitle>
+          <Badge variant="secondary">{scoreCard.score.label}</Badge>
+        </div>
+        <p className="text-sm leading-7 text-muted-foreground">
+          The fastest read on what matters today and what Overload has learned so far.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">What should I do today?</h2>
+          <p className="text-2xl font-semibold text-foreground">{scoreCard.recommended_action.title}</p>
+          <p className="text-sm leading-6 text-muted-foreground">{scoreCard.recommended_action.detail}</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">Why this is showing up</h2>
+          <p className="text-base leading-7 text-foreground">{reason}</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">How sure Overload is</h2>
+          <p className="text-sm leading-6 text-muted-foreground">{confidenceCopy}</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">New learning</h2>
+          <div className="rounded-xl border border-border/70 bg-background/90 p-4">
+            <p className="font-medium text-foreground">{newLearning}</p>
+          </div>
+        </section>
+
+        <ActionPlan
+          score={scoreCard.score.score}
+          trend={trend}
+          dangerStreak={dangerStreak}
+          dangerDaysAhead={dangerDaysAhead}
+          recoveryDate={recoveryDate}
+          plan={plan}
+          note={todayCheckIn?.note ?? undefined}
+          stress={todayCheckIn?.stress}
+          consecutiveDays={dangerStreak}
+          role={todayCheckIn?.role_snapshot ?? ""}
+          smallWins={todayCheckIn?.small_wins ?? null}
+        />
+
+        <NextDayFeedbackCard whatWorked={whatWorkedToday} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -16,6 +16,45 @@ export interface ScoreOutput {
   signals: Signal[];
 }
 
+export type RecommendationState = "generic" | "observed" | "emerging" | "confirmed";
+export type PersonalizationKind = "trigger" | "recovery" | "experiment";
+
+export interface RecommendationBasis {
+  kind: PersonalizationKind;
+  state: RecommendationState;
+  summary: string;
+  evidence_count: number;
+}
+
+export interface BriefingChange {
+  title: string;
+  body: string;
+}
+
+export interface PersonalizationProgressSummary {
+  confirmed_triggers: number;
+  confirmed_recovery_levers: number;
+  experiments: number;
+  confidence_trend: string;
+}
+
+export interface PlaybookItem {
+  key: string;
+  title: string;
+  detail: string;
+  kind: PersonalizationKind;
+  state: RecommendationState;
+  evidence_count: number;
+  last_seen_date: string;
+  trend: string;
+}
+
+export interface PlaybookSections {
+  confirmed_triggers: PlaybookItem[];
+  confirmed_recovery_levers: PlaybookItem[];
+  experiments: PlaybookItem[];
+}
+
 export type InsightConfidence = "low" | "medium" | "high";
 export type ForecastDirection = "down" | "stable" | "up";
 
@@ -110,6 +149,7 @@ export interface ScoreCardResult {
   follow_up: FollowUpInfo | null;
   streak_forgiven: boolean;
   streak_milestones: StreakMilestone[];
+  feedback_submitted_for_today: boolean;
 }
 
 export interface CheckIn {
@@ -217,6 +257,10 @@ export interface InsightBundle {
   what_worked_today: WhatWorkedToday | null;
   streak_milestones: StreakMilestone[];
   streak_forgiven: boolean;
+  personalization_progress: PersonalizationProgressSummary;
+  recommendation_basis: RecommendationBasis | null;
+  briefing_change: BriefingChange | null;
+  playbook: PlaybookSections;
 }
 
 // NotificationPrefs matches handler.NotifPrefsResponse exactly.

--- a/frontend/lib/validators.ts
+++ b/frontend/lib/validators.ts
@@ -106,13 +106,11 @@ export const parseNotificationPrefs = (value: unknown): NotificationPrefs => {
 
 export const parseInsightBundle = (value: unknown): InsightBundle => {
   if (!isRecord(value)) throw new Error("Invalid API response: insight bundle must be an object.");
-  if (
-    !Array.isArray(value.patterns) ||
-    !Array.isArray(value.pattern_insights) ||
-    !Array.isArray(value.recovery_feedback) ||
-    !Array.isArray(value.dismissed_components)
-  ) {
-    throw new Error("Invalid API response: insight bundle arrays are malformed.");
-  }
+  if (!Array.isArray(value.patterns)) throw new Error("Invalid API response: patterns must be an array.");
+  if (!Array.isArray(value.pattern_insights)) throw new Error("Invalid API response: pattern_insights must be an array.");
+  if (!Array.isArray(value.recovery_feedback)) throw new Error("Invalid API response: recovery_feedback must be an array.");
+  if (!Array.isArray(value.dismissed_components)) throw new Error("Invalid API response: dismissed_components must be an array.");
+  if (!isRecord(value.personalization_progress)) throw new Error("Invalid API response: personalization_progress must be an object.");
+  if (!isRecord(value.playbook)) throw new Error("Invalid API response: playbook must be an object.");
   return value as unknown as InsightBundle;
 };


### PR DESCRIPTION
## Summary
- Reshape dashboard around Today's Briefing as the dominant top-of-page surface
- Add PersonalizationProgress card showing confirmed triggers, recovery levers, and experiments
- Add PlaybookPanel for durable memory rendering
- Add /dashboard/playbook route for deeper playbook review
- Add personalization data model to backend InsightBundle (progress, recommendation_basis, briefing_change, playbook)
- Add Playbook nav item with 5-column mobile nav

## Test Plan
- [ ] Open /dashboard and confirm Today's Briefing is first dominant surface
- [ ] Confirm Personalization Progress renders below briefing
- [ ] Confirm compact playbook preview renders on /dashboard  
- [ ] Open /dashboard/playbook and confirm all three sections render
- [ ] Frontend tests pass: npm test
- [ ] Backend tests pass: go test ./...