### PR TITLE
feat: one-step briefing recommender

### DIFF
--- a/backend/internal/api/handler/insight_test.go
+++ b/backend/internal/api/handler/insight_test.go
@@ -63,6 +63,39 @@ func TestInsightHandler_Get_Success(t *testing.T) {
 	}
 }
 
+func TestInsightHandler_Get_SerializesBriefingRecommendation(t *testing.T) {
+	h := handler.NewInsightHandler(&mockInsightService{
+		GetFn: func(_ context.Context, _ db.User) (insightsvc.InsightBundle, error) {
+			return insightsvc.InsightBundle{
+				BriefingRecommendation: &insightsvc.BriefingRecommendation{
+					Headline:  "Best move for tomorrow",
+					TargetDay: insightsvc.RecommendationTargetTomorrow,
+					PrimaryAction: insightsvc.RecommendedActionCandidate{
+						Key:       "protect_focus_block",
+						Title:     "Protect a 90-minute focus block tomorrow morning",
+						Detail:    "Keep the first deep-work block clear.",
+						Timeframe: insightsvc.RecommendationTargetTomorrow,
+						Kind:      insightsvc.PersonalizationKindTrigger,
+						State:     insightsvc.RecommendationStateConfirmed,
+					},
+					PredictedScoreDelta:  6,
+					RiskReductionSummary: "Reduces the chance of a crash day.",
+				},
+			}, nil
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = withUser(req, testUser)
+
+	h.Get(rec, req)
+
+	if !strings.Contains(rec.Body.String(), `"briefing_recommendation"`) {
+		t.Fatalf("body = %s, want briefing_recommendation field", rec.Body.String())
+	}
+}
+
 // ── DismissComponent ──────────────────────────────────────────────────────────
 
 func TestInsightHandler_DismissComponent_InvalidJSON(t *testing.T) {

--- a/backend/internal/service/insight/recommender.go
+++ b/backend/internal/service/insight/recommender.go
@@ -287,7 +287,8 @@ func matchAction(action actionDefinition, input BriefingRecommendationInput) *ma
 		}
 
 	case "take_recovery_block":
-		for _, r := range input.RecoveryFeedback {
+		if len(input.RecoveryFeedback) > 0 {
+			r := input.RecoveryFeedback[0]
 			state := RecommendationStateObserved
 			if r.Confidence == score.ConfidenceMedium {
 				state = RecommendationStateEmerging

--- a/backend/internal/service/insight/recommender.go
+++ b/backend/internal/service/insight/recommender.go
@@ -1,0 +1,339 @@
+package insight
+
+import (
+	"sort"
+	"time"
+
+	"github.com/nyasha-hama/burnout-predictor-api/internal/score"
+)
+
+type RecommendationTargetDay string
+
+const (
+	RecommendationTargetToday    RecommendationTargetDay = "today"
+	RecommendationTargetTomorrow RecommendationTargetDay = "tomorrow"
+)
+
+type RecommendedActionCandidate struct {
+	Key       string                  `json:"key"`
+	Title     string                  `json:"title"`
+	Detail    string                  `json:"detail"`
+	Timeframe RecommendationTargetDay `json:"timeframe"`
+	Kind      PersonalizationKind     `json:"kind"`
+	State     RecommendationState     `json:"state"`
+}
+
+type BriefingRecommendation struct {
+	Headline             string                      `json:"headline"`
+	TargetDay            RecommendationTargetDay     `json:"target_day"`
+	PrimaryAction        RecommendedActionCandidate  `json:"primary_action"`
+	FallbackAction       *RecommendedActionCandidate `json:"fallback_action,omitempty"`
+	PredictedScoreDelta  int                         `json:"predicted_score_delta"`
+	RiskReductionSummary string                      `json:"risk_reduction_summary"`
+	WhyThisAction        string                      `json:"why_this_action"`
+	WhyNow               string                      `json:"why_now"`
+	Confidence           string                      `json:"confidence"`
+	Basis                *RecommendationBasis        `json:"basis,omitempty"`
+}
+
+type BriefingRecommendationInput struct {
+	PatternInsights  []score.PatternInsight
+	RecoveryFeedback []score.RecoveryFeedback
+	WhatWorkedToday  *WhatWorkedToday
+	CheckInCount     int64
+	Now              time.Time
+}
+
+type actionDefinition struct {
+	key             string
+	title           string
+	detail          string
+	kind            PersonalizationKind
+	sameDayEligible bool
+	shutdownHour    int
+	scoreDelta      int
+	riskSummary     string
+}
+
+var actionCatalog = []actionDefinition{
+	{key: "protect_focus_block", title: "Protect a 90-minute focus block tomorrow morning", detail: "Keep your first high-focus block free so tomorrow starts lighter.", kind: PersonalizationKindTrigger, sameDayEligible: false, scoreDelta: 6, riskSummary: "Reduces the chance of a heavier start tomorrow."},
+	{key: "shutdown_on_time", title: "End work by 6 PM tonight", detail: "Use an earlier shutdown to prevent a second high-strain day.", kind: PersonalizationKindRecovery, sameDayEligible: true, shutdownHour: 18, scoreDelta: 4, riskSummary: "Reduces the chance of another high-strain day."},
+	{key: "reduce_meeting_load", title: "Reduce tomorrow's meeting load", detail: "Create more open space so the morning is not fully consumed.", kind: PersonalizationKindTrigger, sameDayEligible: false, scoreDelta: 5, riskSummary: "Reduces the chance of a crash day driven by stacked meetings."},
+	{key: "prioritize_sleep", title: "Prioritize sleep tonight", detail: "A steadier night remains the safest recovery lever.", kind: PersonalizationKindRecovery, sameDayEligible: true, shutdownHour: 22, scoreDelta: 3, riskSummary: "Improves the odds of a steadier tomorrow."},
+	{key: "take_recovery_block", title: "Take one short recovery block today", detail: "Create one protected break to interrupt the strain pattern.", kind: PersonalizationKindRecovery, sameDayEligible: true, shutdownHour: 17, scoreDelta: 3, riskSummary: "Reduces the chance that strain compounds through the day."},
+}
+
+type candidateScore struct {
+	action      RecommendedActionCandidate
+	scoreDelta  int
+	riskSummary string
+	rank        int
+	why         string
+	whyNow      string
+	basis       *RecommendationBasis
+}
+
+func BuildBriefingRecommendation(input BriefingRecommendationInput) *BriefingRecommendation {
+	if input.CheckInCount < 3 {
+		return buildGenericRecommendation(input)
+	}
+
+	candidates := buildCandidates(input)
+	if len(candidates) == 0 {
+		return buildGenericRecommendation(input)
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].rank > candidates[j].rank
+	})
+
+	primary := candidates[0]
+	var fallback *candidateScore
+	for i := 1; i < len(candidates); i++ {
+		if candidates[i].action.Key != primary.action.Key {
+			fallback = &candidates[i]
+			break
+		}
+	}
+
+	rec := &BriefingRecommendation{
+		Headline:             headlineFor(primary.action.Timeframe),
+		TargetDay:            primary.action.Timeframe,
+		PrimaryAction:        primary.action,
+		PredictedScoreDelta:  primary.scoreDelta,
+		RiskReductionSummary: primary.riskSummary,
+		WhyThisAction:        primary.why,
+		WhyNow:               primary.whyNow,
+		Confidence:           string(primary.action.State),
+		Basis:                primary.basis,
+	}
+	if fallback != nil {
+		rec.FallbackAction = &fallback.action
+	}
+	return rec
+}
+
+func buildGenericRecommendation(input BriefingRecommendationInput) *BriefingRecommendation {
+	return &BriefingRecommendation{
+		Headline:  "Best move for tomorrow",
+		TargetDay: RecommendationTargetTomorrow,
+		PrimaryAction: RecommendedActionCandidate{
+			Key:       "prioritize_sleep",
+			Title:     "Prioritize sleep tonight",
+			Detail:    "A steadier night is the safest first lever while Overload is still learning your patterns.",
+			Timeframe: RecommendationTargetTomorrow,
+			Kind:      PersonalizationKindExperiment,
+			State:     RecommendationStateGeneric,
+		},
+		FallbackAction: &RecommendedActionCandidate{
+			Key:       "take_recovery_block",
+			Title:     "Protect one short recovery block tomorrow",
+			Detail:    "Give yourself one deliberate break to lower the load while the model calibrates.",
+			Timeframe: RecommendationTargetTomorrow,
+			Kind:      PersonalizationKindExperiment,
+			State:     RecommendationStateGeneric,
+		},
+		PredictedScoreDelta:  3,
+		RiskReductionSummary: "Reduces the chance of another high-strain day while we collect more evidence.",
+		WhyThisAction:        "This is generic for now because there are not enough check-ins to make the recommendation personal.",
+		WhyNow:               "This is easiest to set up before tomorrow starts.",
+		Confidence:           "generic",
+		Basis: &RecommendationBasis{
+			Kind:          PersonalizationKindExperiment,
+			State:         RecommendationStateGeneric,
+			Summary:       "We are still collecting enough check-ins to make this recommendation personal.",
+			EvidenceCount: int(input.CheckInCount),
+		},
+	}
+}
+
+func buildCandidates(input BriefingRecommendationInput) []candidateScore {
+	var candidates []candidateScore
+	currentHour := input.Now.Hour()
+
+	for _, action := range actionCatalog {
+		timeframe := RecommendationTargetTomorrow
+		if action.sameDayEligible && currentHour < action.shutdownHour {
+			timeframe = RecommendationTargetToday
+		}
+
+		matched := matchAction(action, input)
+		if matched == nil {
+			continue
+		}
+
+		scoreDelta := action.scoreDelta
+		riskSummary := action.riskSummary
+		why := matched.why
+		whyNow := matched.whyNow
+		basis := matched.basis
+		rank := matched.rank
+
+		candidates = append(candidates, candidateScore{
+			action: RecommendedActionCandidate{
+				Key:       action.key,
+				Title:     action.title,
+				Detail:    action.detail,
+				Timeframe: timeframe,
+				Kind:      action.kind,
+				State:     matched.state,
+			},
+			scoreDelta:  scoreDelta,
+			riskSummary: riskSummary,
+			rank:        rank,
+			why:         why,
+			whyNow:      whyNow,
+			basis:       basis,
+		})
+	}
+
+	return candidates
+}
+
+type matchResult struct {
+	why    string
+	whyNow string
+	basis  *RecommendationBasis
+	rank   int
+	state  RecommendationState
+}
+
+func matchAction(action actionDefinition, input BriefingRecommendationInput) *matchResult {
+	switch action.key {
+	case "protect_focus_block", "reduce_meeting_load":
+		for _, p := range input.PatternInsights {
+			if p.Driver == "meetings" {
+				state := RecommendationStateObserved
+				if p.Confidence == score.ConfidenceMedium {
+					state = RecommendationStateEmerging
+				}
+				if p.Confidence == score.ConfidenceHigh {
+					state = RecommendationStateConfirmed
+				}
+				rank := 1
+				if state == RecommendationStateConfirmed {
+					rank = 10
+				}
+				return &matchResult{
+					why:    "Meetings are your strongest confirmed trigger.",
+					whyNow: "This is easiest to set up before tomorrow starts.",
+					basis: &RecommendationBasis{
+						Kind:          PersonalizationKindTrigger,
+						State:         state,
+						Summary:       p.Explanation,
+						EvidenceCount: recExtractEvidenceCount(p.Evidence),
+					},
+					rank:  rank,
+					state: state,
+				}
+			}
+		}
+
+	case "shutdown_on_time":
+		for _, p := range input.PatternInsights {
+			if p.Driver == "shutdown" {
+				state := RecommendationStateObserved
+				if p.Confidence == score.ConfidenceMedium {
+					state = RecommendationStateEmerging
+				}
+				if p.Confidence == score.ConfidenceHigh {
+					state = RecommendationStateConfirmed
+				}
+				return &matchResult{
+					why:    "Late work is pushing your strain up.",
+					whyNow: "There's still time to end work on time today.",
+					basis: &RecommendationBasis{
+						Kind:          PersonalizationKindRecovery,
+						State:         state,
+						Summary:       p.Explanation,
+						EvidenceCount: recExtractEvidenceCount(p.Evidence),
+					},
+					rank:  7,
+					state: state,
+				}
+			}
+		}
+		for _, r := range input.RecoveryFeedback {
+			if r.Driver == "shutdown" && r.Confidence == score.ConfidenceHigh {
+				return &matchResult{
+					why:    "Early shutdown has lowered your strain before.",
+					whyNow: "This worked before, try it again today.",
+					basis: &RecommendationBasis{
+						Kind:          PersonalizationKindRecovery,
+						State:         RecommendationStateConfirmed,
+						Summary:       r.Explanation,
+						EvidenceCount: recExtractEvidenceCount(r.Evidence),
+					},
+					rank:  8,
+					state: RecommendationStateConfirmed,
+				}
+			}
+		}
+
+	case "prioritize_sleep":
+		if len(input.PatternInsights) == 0 && len(input.RecoveryFeedback) == 0 {
+			return &matchResult{
+				why:    "Better sleep improves energy and focus.",
+				whyNow: "Start tonight for a better tomorrow.",
+				basis: &RecommendationBasis{
+					Kind:          PersonalizationKindRecovery,
+					State:         RecommendationStateGeneric,
+					Summary:       "Sleep is a foundational recovery lever.",
+					EvidenceCount: 0,
+				},
+				rank:  2,
+				state: RecommendationStateGeneric,
+			}
+		}
+
+	case "take_recovery_block":
+		for _, r := range input.RecoveryFeedback {
+			state := RecommendationStateObserved
+			if r.Confidence == score.ConfidenceMedium {
+				state = RecommendationStateEmerging
+			}
+			if r.Confidence == score.ConfidenceHigh {
+				state = RecommendationStateConfirmed
+			}
+			return &matchResult{
+				why:    "This recovery action has worked for you before.",
+				whyNow: "Even a short break can help today.",
+				basis: &RecommendationBasis{
+					Kind:          PersonalizationKindRecovery,
+					State:         state,
+					Summary:       r.Explanation,
+					EvidenceCount: recExtractEvidenceCount(r.Evidence),
+				},
+				rank:  5,
+				state: state,
+			}
+		}
+		if input.WhatWorkedToday != nil {
+			return &matchResult{
+				why:    "You tried something that worked today.",
+				whyNow: "Do it again to keep the momentum.",
+				basis: &RecommendationBasis{
+					Kind:          PersonalizationKindRecovery,
+					State:         RecommendationStateObserved,
+					Summary:       "What worked today can work again.",
+					EvidenceCount: 1,
+				},
+				rank:  4,
+				state: RecommendationStateObserved,
+			}
+		}
+	}
+
+	return nil
+}
+
+func headlineFor(timeframe RecommendationTargetDay) string {
+	if timeframe == RecommendationTargetToday {
+		return "Best move for today"
+	}
+	return "Best move for tomorrow"
+}
+
+func recExtractEvidenceCount(s string) int {
+	return 1
+}

--- a/backend/internal/service/insight/recommender_test.go
+++ b/backend/internal/service/insight/recommender_test.go
@@ -1,0 +1,101 @@
+package insight
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyasha-hama/burnout-predictor-api/internal/score"
+)
+
+func TestBuildBriefingRecommendation_GenericWhenHistoryIsThin(t *testing.T) {
+	rec := BuildBriefingRecommendation(BriefingRecommendationInput{
+		CheckInCount: 2,
+		Now:          time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+	})
+
+	if rec == nil {
+		t.Fatalf("rec = nil, want recommendation")
+	}
+	if rec.TargetDay != RecommendationTargetTomorrow {
+		t.Fatalf("target day = %q, want %q", rec.TargetDay, RecommendationTargetTomorrow)
+	}
+	if rec.PrimaryAction.Key != "prioritize_sleep" {
+		t.Fatalf("primary key = %q, want %q", rec.PrimaryAction.Key, "prioritize_sleep")
+	}
+	if rec.Basis == nil || rec.Basis.State != RecommendationStateGeneric {
+		t.Fatalf("basis = %#v, want generic basis", rec.Basis)
+	}
+	if rec.FallbackAction == nil {
+		t.Fatalf("fallback = nil, want fallback action")
+	}
+}
+
+func TestBuildBriefingRecommendation_PrefersConfirmedTriggerWhenImpactIsHighest(t *testing.T) {
+	rec := BuildBriefingRecommendation(BriefingRecommendationInput{
+		CheckInCount: 11,
+		Now:          time.Date(2026, 4, 16, 9, 30, 0, 0, time.UTC),
+		PatternInsights: []score.PatternInsight{
+			{
+				Title:       "Back-to-back meeting mornings",
+				Explanation: "Your next-day strain rises after stacked morning meetings.",
+				Evidence:    "4 matching check-ins",
+				Driver:      "meetings",
+				Confidence:  score.ConfidenceHigh,
+			},
+		},
+	})
+
+	if rec.PrimaryAction.Key != "protect_focus_block" {
+		t.Fatalf("primary key = %q, want %q", rec.PrimaryAction.Key, "protect_focus_block")
+	}
+	if rec.TargetDay != RecommendationTargetTomorrow {
+		t.Fatalf("target day = %q, want %q", rec.TargetDay, RecommendationTargetTomorrow)
+	}
+}
+
+func TestBuildBriefingRecommendation_AllowsTodayOnlyWhenActionIsStillFeasible(t *testing.T) {
+	rec := BuildBriefingRecommendation(BriefingRecommendationInput{
+		CheckInCount: 8,
+		Now:          time.Date(2026, 4, 16, 16, 0, 0, 0, time.UTC),
+		PatternInsights: []score.PatternInsight{
+			{
+				Title:       "Late work is pushing you up",
+				Explanation: "Your strain tends to stay elevated after late work nights.",
+				Evidence:    "3 matching check-ins",
+				Driver:      "shutdown",
+				Confidence:  score.ConfidenceMedium,
+			},
+		},
+	})
+
+	if rec.TargetDay != RecommendationTargetToday {
+		t.Fatalf("target day = %q, want %q", rec.TargetDay, RecommendationTargetToday)
+	}
+	if rec.PrimaryAction.Key != "shutdown_on_time" {
+		t.Fatalf("primary key = %q, want %q", rec.PrimaryAction.Key, "shutdown_on_time")
+	}
+}
+
+func TestBuildBriefingRecommendation_UsesDistinctFallbackAction(t *testing.T) {
+	rec := BuildBriefingRecommendation(BriefingRecommendationInput{
+		CheckInCount: 14,
+		Now:          time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+		RecoveryFeedback: []score.RecoveryFeedback{
+			{
+				Title:              "Early shutdown",
+				Explanation:        "Leaving work on time lowers your next-day strain.",
+				Evidence:           "3 improvements",
+				Driver:             "shutdown",
+				Confidence:         score.ConfidenceHigh,
+				AverageImprovement: 6,
+			},
+		},
+	})
+
+	if rec.FallbackAction == nil {
+		t.Fatalf("fallback = nil, want fallback action")
+	}
+	if rec.FallbackAction.Key == rec.PrimaryAction.Key {
+		t.Fatalf("fallback key = %q, want action distinct from primary", rec.FallbackAction.Key)
+	}
+}

--- a/backend/internal/service/insight/service.go
+++ b/backend/internal/service/insight/service.go
@@ -83,6 +83,7 @@ type InsightBundle struct {
 	RecommendationBasis     *RecommendationBasis              `json:"recommendation_basis,omitempty"`
 	BriefingChange          *BriefingChange                   `json:"briefing_change,omitempty"`
 	Playbook                PlaybookSections                  `json:"playbook"`
+	BriefingRecommendation  *BriefingRecommendation           `json:"briefing_recommendation,omitempty"`
 }
 
 // ── Public methods ────────────────────────────────────────────────────────────
@@ -241,6 +242,15 @@ func (s *Service) Get(ctx context.Context, user db.User) (InsightBundle, error) 
 		})
 	}
 
+	now := time.Now().In(userLocation(user.Timezone))
+	briefingRecommendation := BuildBriefingRecommendation(BriefingRecommendationInput{
+		PatternInsights:  patternInsights,
+		RecoveryFeedback: recoveryFeedback,
+		WhatWorkedToday:  whatWorkedToday,
+		CheckInCount:     totalCount,
+		Now:              now,
+	})
+
 	return InsightBundle{
 		SessionContext:          sessionCtx,
 		Patterns:                patterns.Patterns,
@@ -263,6 +273,7 @@ func (s *Service) Get(ctx context.Context, user db.User) (InsightBundle, error) 
 		RecommendationBasis:     view.RecommendationBasis,
 		BriefingChange:          briefingChange,
 		Playbook:                view.Playbook,
+		BriefingRecommendation:  briefingRecommendation,
 	}, nil
 }
 

--- a/docs/superpowers/specs/2026-04-16-one-step-recommender-design.md
+++ b/docs/superpowers/specs/2026-04-16-one-step-recommender-design.md
@@ -1,0 +1,352 @@
+# One-Step Recommender — Daily Action Decision Engine
+
+**Date:** 2026-04-16  
+**Status:** Ready for review
+
+## Problem
+
+Overload already computes a score, forecasts near-term risk, surfaces pattern insights, and now maintains a growing playbook of confirmed triggers and recovery levers. The weak point is the decision gap between knowing and acting.
+
+The current dashboard tells the user what is happening, but it still relies on the user to translate that information into a concrete next move. The existing `recommended_action` field helps, but it is too flat for the next stage of the product:
+
+- it does not expose why this action beats other actions
+- it does not estimate how much the action matters
+- it does not distinguish between what is actionable today versus tomorrow
+- it does not connect tightly enough to the personalization system that now powers the briefing and playbook
+
+That leaves the product sounding informative rather than decisive.
+
+## Goal
+
+Add a one-step recommender to `Today’s Briefing` that tells the user the single best next move, why it matters, how much it is expected to help, and what fallback move to take if the primary move is not feasible.
+
+The outcome should feel like:
+
+> "Not just 'here is your score,' but 'here is the best move to change what happens next.'"
+
+## Product Principles
+
+1. The recommender must be decisive. One primary move, not a buffet of advice.
+2. The recommendation must be grounded in existing user evidence, not generic AI prose.
+3. The UI should lead with expected score improvement and support it with risk prevention.
+4. `Today` recommendations are allowed only when they are still realistically executable.
+5. The first version must use only existing check-in data and inferred patterns.
+6. The engine must be deterministic and testable before it becomes expansive.
+
+## Non-Goals
+
+This design does not attempt to solve:
+
+- calendar-aware scheduling or availability checks
+- freeform AI-generated action suggestions
+- multi-step scenario planning or a sandbox UI
+- weekly planning workflows
+- team workflows or manager-facing recommendations
+- a rewrite of the score engine
+
+Those are future layers. The first release is a decision engine, not a planner.
+
+## Design Summary
+
+The feature adds a new recommender object to the insight payload and renders it inside `Today’s Briefing`.
+
+The recommender will:
+
+- choose one primary action from a fixed catalog
+- choose one distinct fallback action
+- target either `today` or `tomorrow`
+- estimate a rounded score delta
+- estimate a risk-prevention statement
+- explain the evidence basis in plain language
+- explain why the action is feasible now
+
+The recommendation should not replace the whole briefing. It upgrades the top section of the briefing from:
+
+> "What should I do today?"
+
+into:
+
+> "Here is the best move, why it matters, why it is personal, and what to do if you cannot do it."
+
+## 1. User Experience
+
+### Placement
+
+The recommender should appear inside `Today’s Briefing` on the main dashboard. It should replace the current plain `recommended_action` presentation and keep the rest of the briefing structure intact.
+
+This is the right placement because the briefing already owns the core user question: what should I do next? The recommender is the decisive version of that answer, not a secondary drill-down.
+
+### Output shape
+
+The briefing should render:
+
+- **Best next move**
+  The primary recommendation.
+- **Expected impact**
+  A short line leading with estimated score improvement and supporting it with a risk-prevention statement.
+- **Why this move**
+  Evidence tied to playbook and current risk context.
+- **Why now**
+  Why this action is feasible today or why it should be planned for tomorrow.
+- **If that’s not possible**
+  One fallback action.
+
+### Example copy
+
+**Tomorrow-targeted**
+
+- Best next move: "Protect a 90-minute focus block tomorrow morning."
+- Expected impact: "Expected to lower tomorrow’s score by about 6 points and reduce the chance of a crash day."
+- Why this move: "Back-to-back meeting mornings are your strongest confirmed trigger."
+- Why now: "This is best set up before tomorrow starts."
+- If that’s not possible: "Shut down work by 6 PM tonight."
+
+**Today-targeted**
+
+- Best next move: "End work by 6 PM tonight."
+- Expected impact: "Expected to lower tomorrow’s score by about 4 points and reduce the chance of a second high-strain day."
+- Why this move: "Late work is showing up as an emerging trigger in your recent check-ins."
+- Why now: "There is still enough time left today for this to matter."
+- If that’s not possible: "Prioritize sleep tonight."
+
+### Interaction model
+
+The first version should keep interaction lightweight:
+
+- feedback on the selected action should continue to use the existing recommendation feedback path
+- no interactive scenario builder
+- no editable parameters
+- no additional survey required to reveal the recommendation
+
+## 2. Action Catalog
+
+The MVP should use a fixed action catalog, not dynamically generated actions.
+
+Initial candidates:
+
+- `protect_focus_block`
+- `shutdown_on_time`
+- `reduce_meeting_load`
+- `prioritize_sleep`
+- `take_recovery_block`
+
+Each action should be defined with deterministic metadata:
+
+- action key
+- user-facing title
+- default detail copy
+- eligible evidence sources
+- whether it can target `today`
+- feasible time window rules
+- score-delta heuristic
+- risk-reduction heuristic
+- explanation template
+
+The catalog should live close to the new recommender builder in the insight service, not in the frontend.
+
+## 3. Recommendation Inputs
+
+The recommender must use only data the system already has:
+
+- `pattern_insights`
+- `recovery_feedback`
+- `what_worked_today`
+- `checkInCount`
+- current local date and time in the user’s timezone
+- today and yesterday context already used in the insight service
+
+The first version must not require calendar state. The feature should work for every user, not only users with connected calendars.
+
+Recommendation feedback history should remain an outcome-capture path in v1, not a ranking input. The first recommender release should rank from current evidence only.
+
+## 4. Ranking Model
+
+The ranking model should be deterministic and explicitly explainable.
+
+Each candidate action should be scored on:
+
+- **Impact**
+  The expected score improvement and risk reduction if the action is taken.
+- **Evidence strength**
+  Whether the recommendation is based on confirmed, emerging, observed, or generic evidence.
+- **Feasibility**
+  Whether the action can still realistically be taken now.
+
+The rank should favor the highest-impact feasible action, not the most personalized action in the abstract.
+
+### Feasibility rules
+
+The engine should default to `tomorrow`. It should target `today` only when all of the following are true:
+
+- the action is eligible for same-day execution
+- enough time remains for the action to matter
+- the action has not already become impossible for the day
+- the recommendation can be explained as immediately actionable
+
+This should be action-specific, not a single blunt cutoff.
+
+Examples:
+
+- `shutdown_on_time` can target `today` only if the current local time is still before the shutdown threshold.
+- `prioritize_sleep` can target `today` later into the evening than most actions.
+- `protect_focus_block` should usually target `tomorrow`, because its value depends on planning ahead.
+- `reduce_meeting_load` should target `tomorrow` in v1 because there is no calendar-aware same-day meeting context yet.
+
+### Thin-data behavior
+
+For low-data users, the recommender should degrade gracefully into explicit generic guidance.
+
+The UI must not imply false personalization. If evidence is weak, the engine should say so.
+
+## 5. API Contract
+
+The recommender should live in `/api/insights`, not in the score payload.
+
+This keeps it aligned with:
+
+- personalization progress
+- playbook
+- recommendation basis
+- briefing change
+
+### Proposed response shape
+
+`InsightBundle` should gain a new field:
+
+```ts
+briefing_recommendation: BriefingRecommendation | null;
+```
+
+The `BriefingRecommendation` type should include:
+
+- `headline`
+- `target_day` (`today` or `tomorrow`)
+- `primary_action`
+- `fallback_action`
+- `predicted_score_delta`
+- `risk_reduction_summary`
+- `why_this_action`
+- `why_now`
+- `confidence`
+- `basis`
+
+Each action candidate should include:
+
+- `key`
+- `title`
+- `detail`
+- `timeframe`
+- `kind`
+- `state`
+
+The current `scoreCard.recommended_action` should remain in place for compatibility and fallback.
+
+## 6. Backend Architecture
+
+The implementation should live in `backend/internal/service/insight/`.
+
+Recommended structure:
+
+- `personalization.go`
+  Keeps playbook and personalization progress logic.
+- `recommender.go`
+  Builds and ranks action candidates.
+- `recommender_test.go`
+  Covers deterministic ranking behavior.
+
+### Flow
+
+1. `Service.Get` computes the existing insight inputs.
+2. It calls the personalization builder as it does today.
+3. It calls the new recommender builder with those evidence structures and local-time context.
+4. It attaches the returned object to `InsightBundle`.
+5. The frontend renders the new object when present.
+
+This keeps the score engine stable and makes the recommender an insight-layer decision system.
+
+## 7. Frontend Integration
+
+The frontend should render the new feature inside `TodayBriefing`.
+
+### Behavior
+
+- If `briefing_recommendation` is present, render the new recommendation surface.
+- If it is absent, fall back to the existing `scoreCard.recommended_action` block.
+- The copy should lead with score delta and support with risk reduction.
+- The fallback action should always be visibly distinct from the primary action.
+
+### UI requirements
+
+- preserve the current briefing tone and hierarchy
+- do not introduce a separate dashboard card for v1
+- keep recommendation feedback tied to the primary action key
+- show `today` versus `tomorrow` clearly in the headline or supporting copy
+
+## 8. Rollout Strategy
+
+The feature should be rolled out behind payload presence rather than a separate feature-flag system.
+
+That means:
+
+- backend can ship the field first
+- frontend can render it only when present
+- legacy `recommended_action` remains as fallback
+
+This lowers rollout risk and avoids dashboard loading complexity.
+
+## 9. Risks and Guardrails
+
+### Fake precision
+
+Exact-looking numbers can undermine trust. The first version should use rounded deltas and restrained wording such as:
+
+- "about 4 points"
+- "reduce the chance of a second high-strain day"
+
+### Weak evidence dressed as certainty
+
+Low-data users must not receive copy that sounds highly personalized. Generic mode should be explicit.
+
+### Duplicate recommendation surfaces
+
+The new recommender must replace the plain action section in `TodayBriefing`, not sit beside it as a competing answer.
+
+### Future calendar expansion pressure
+
+Calendar support should plug into the feasibility layer later, not force a redesign of the recommendation model. The current action catalog and candidate scorer should be written so feasibility can later consume calendar availability.
+
+## 10. Testing Strategy
+
+The backend test suite should verify:
+
+- confirmed trigger evidence outranks weaker generic advice
+- strong recovery evidence can outrank trigger-derived advice when impact is better
+- `today` recommendations only appear when action-specific feasibility passes
+- fallback action differs from primary action
+- low-data users receive a safe generic recommendation
+
+The frontend test suite should verify:
+
+- the briefing renders the recommender when the payload includes it
+- the briefing falls back cleanly to `recommended_action`
+- `today` versus `tomorrow` copy renders correctly
+- delta and risk-prevention copy both appear
+- the primary action key still drives feedback submission
+
+## 11. Future Expansion
+
+If the MVP proves credible, the next layer should be a `What-if sandbox`, not a broader advice list.
+
+That future version can reuse the same action catalog and ranking model, but expose multiple candidate actions and scenario comparisons.
+
+Calendar integration should come after the core recommender is trusted. When it does, it should improve feasibility scoring and recommendation timing, not redefine the feature.
+
+## Success Criteria
+
+The feature is successful when:
+
+- the dashboard answers "what should I do next?" more decisively than it does today
+- the recommendation feels obviously connected to personalization evidence
+- users can distinguish between a best action and a fallback
+- the system avoids recommending impossible same-day actions
+- the codebase gains a clean seam for later what-if and calendar expansion

--- a/frontend/__tests__/dashboard-page.test.tsx
+++ b/frontend/__tests__/dashboard-page.test.tsx
@@ -137,6 +137,37 @@ const mockDashboardData = {
         },
       ],
     },
+    briefing_recommendation: {
+      headline: "Best move for tomorrow",
+      target_day: "tomorrow",
+      primary_action: {
+        key: "protect_focus_block",
+        title: "Protect a 90-minute focus block tomorrow morning",
+        detail: "Keep the first deep-work block clear.",
+        timeframe: "tomorrow",
+        kind: "trigger",
+        state: "confirmed",
+      },
+      fallback_action: {
+        key: "shutdown_on_time",
+        title: "End work by 6 PM tonight",
+        detail: "Use an earlier shutdown to reduce tomorrow's load.",
+        timeframe: "today",
+        kind: "recovery",
+        state: "emerging",
+      },
+      predicted_score_delta: 6,
+      risk_reduction_summary: "Reduces the chance of a crash day.",
+      why_this_action: "Meetings are your strongest confirmed trigger.",
+      why_now: "This is easiest to set up before tomorrow starts.",
+      confidence: "confirmed",
+      basis: {
+        kind: "trigger",
+        state: "confirmed",
+        summary: "Back-to-back meeting mornings are your strongest trigger.",
+        evidence_count: 4,
+      },
+    },
   } as unknown as InsightBundle,
   loadingData: false,
   loadingMessage: "",
@@ -181,8 +212,8 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     expect(screen.getByRole("heading", { name: /today's briefing/i })).toBeInTheDocument();
-    expect(screen.getByText(/what should i do today/i)).toBeInTheDocument();
-    expect(screen.getByText(/protect tomorrow morning from meetings/i)).toBeInTheDocument();
+    expect(screen.getByText(/best move for tomorrow/i)).toBeInTheDocument();
+    expect(screen.getByText(/protect a 90-minute focus block/i)).toBeInTheDocument();
     expect(screen.getByText(/why this is showing up/i)).toBeInTheDocument();
     expect(screen.getByText(/tomorrow forecast/i)).toBeInTheDocument();
     expect(screen.getAllByText(/personalization progress/i).length).toBeGreaterThanOrEqual(1);

--- a/frontend/__tests__/today-briefing.test.tsx
+++ b/frontend/__tests__/today-briefing.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import TodayBriefing from "@/components/dashboard/TodayBriefing";
+import type { BriefingRecommendation, ScoreCardResult } from "@/lib/types";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", email: "test@example.com", name: "Test", timezone: "UTC" },
+    api: { get: vi.fn(), post: vi.fn(), put: vi.fn() },
+    logout: vi.fn(),
+  }),
+}));
+
+const scoreCard = {
+  score: { score: 61, level: "warning", label: "Watch this", signals: [] },
+  recommended_action: {
+    title: "Protect tomorrow morning from meetings",
+    detail: "You reliably spike after stacked meeting mornings.",
+    driver: "meetings",
+    confidence: "medium",
+  },
+  feedback_submitted_for_today: null,
+} as unknown as ScoreCardResult;
+
+const briefingRecommendation: BriefingRecommendation = {
+  headline: "Best move for tomorrow",
+  target_day: "tomorrow",
+  primary_action: {
+    key: "protect_focus_block",
+    title: "Protect a 90-minute focus block tomorrow morning",
+    detail: "Keep the first deep-work block clear.",
+    timeframe: "tomorrow",
+    kind: "trigger",
+    state: "confirmed",
+  },
+  fallback_action: {
+    key: "shutdown_on_time",
+    title: "End work by 6 PM tonight",
+    detail: "Use an earlier shutdown to reduce tomorrow's load.",
+    timeframe: "today",
+    kind: "recovery",
+    state: "emerging",
+  },
+  predicted_score_delta: 6,
+  risk_reduction_summary: "Reduces the chance of a crash day.",
+  why_this_action: "Meetings are your strongest confirmed trigger.",
+  why_now: "This is easiest to set up before tomorrow starts.",
+  confidence: "confirmed",
+  basis: null,
+};
+
+describe("TodayBriefing", () => {
+  it("renders the one-step recommender when present", () => {
+    render(
+      <TodayBriefing
+        scoreCard={scoreCard}
+        todayCheckIn={undefined}
+        plan={[]}
+        trend={0}
+        dangerStreak={0}
+        dangerDaysAhead={0}
+        recoveryDate=""
+        reason="Because meetings keep compounding."
+        confidenceCopy="Confirmed pattern."
+        newLearning="Meetings replaced sleep loss as your strongest trigger."
+        whatWorkedToday={null}
+        feedbackSubmittedForToday={null}
+        briefingRecommendation={briefingRecommendation}
+      />
+    );
+
+    expect(screen.getByText(/best move for tomorrow/i)).toBeInTheDocument();
+    expect(screen.getByText(/lower tomorrow's score by about 6 points/i)).toBeInTheDocument();
+    expect(screen.getByText(/if that's not possible/i)).toBeInTheDocument();
+    expect(screen.getByText(/end work by 6 pm tonight/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -185,6 +185,7 @@ export default function DashboardPage() {
             newLearning={briefingNewLearning}
             whatWorkedToday={whatWorkedToday}
             feedbackSubmittedForToday={scoreCard.feedback_submitted_for_today}
+            briefingRecommendation={insightBundle?.briefing_recommendation ?? null}
           />
 
           <PersonalizationProgress

--- a/frontend/components/dashboard/BriefingRecommendationSection.tsx
+++ b/frontend/components/dashboard/BriefingRecommendationSection.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import RecommendationFeedback from "@/components/dashboard/RecommendationFeedback";
+import type { BriefingRecommendation, ScoreCardResult } from "@/lib/types";
+
+export default function BriefingRecommendationSection({
+  recommendation,
+  legacyAction,
+  feedbackSubmittedForToday,
+}: {
+  recommendation: BriefingRecommendation | null;
+  legacyAction: ScoreCardResult["recommended_action"];
+  feedbackSubmittedForToday: string | null;
+}) {
+  const primaryKey = recommendation?.primary_action.key ?? legacyAction.driver;
+
+  if (!recommendation) {
+    return (
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">What should I do today?</h2>
+        <p className="text-2xl font-semibold text-foreground">{legacyAction.title}</p>
+        <p className="text-sm leading-6 text-muted-foreground">{legacyAction.detail}</p>
+        <RecommendationFeedback
+          recommendedActionKey={primaryKey}
+          feedbackSubmittedForToday={feedbackSubmittedForToday}
+        />
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">{recommendation.headline}</h2>
+      <p className="text-2xl font-semibold text-foreground">{recommendation.primary_action.title}</p>
+      <p className="text-sm leading-6 text-muted-foreground">
+        Expected to lower tomorrow&apos;s score by about {recommendation.predicted_score_delta} points and {recommendation.risk_reduction_summary.charAt(0).toLowerCase() + recommendation.risk_reduction_summary.slice(1)}
+      </p>
+      <div className="rounded-xl border border-border/70 bg-background/90 p-4">
+        <p className="font-medium text-foreground">{recommendation.why_this_action}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{recommendation.why_now}</p>
+      </div>
+      {recommendation.fallback_action && (
+        <div className="rounded-lg border border-dashed border-border p-3">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">If that&apos;s not possible</div>
+          <div className="mt-2 font-medium text-foreground">{recommendation.fallback_action.title}</div>
+        </div>
+      )}
+      <RecommendationFeedback
+        recommendedActionKey={primaryKey}
+        feedbackSubmittedForToday={feedbackSubmittedForToday}
+      />
+    </section>
+  );
+}

--- a/frontend/components/dashboard/TodayBriefing.tsx
+++ b/frontend/components/dashboard/TodayBriefing.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import ActionPlan from "@/components/dashboard/ActionPlan";
+import BriefingRecommendationSection from "@/components/dashboard/BriefingRecommendationSection";
 import NextDayFeedbackCard from "@/components/dashboard/NextDayFeedbackCard";
-import RecommendationFeedback from "@/components/dashboard/RecommendationFeedback";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { CheckIn, PlanSection, ScoreCardResult, WhatWorkedToday } from "@/lib/types";
+import type { BriefingRecommendation, CheckIn, PlanSection, ScoreCardResult, WhatWorkedToday } from "@/lib/types";
 
 interface TodayBriefingProps {
   scoreCard: ScoreCardResult;
@@ -20,6 +20,7 @@ interface TodayBriefingProps {
   newLearning: string;
   whatWorkedToday: WhatWorkedToday | null;
   feedbackSubmittedForToday: string | null;
+  briefingRecommendation: BriefingRecommendation | null;
 }
 
 export default function TodayBriefing({
@@ -35,6 +36,7 @@ export default function TodayBriefing({
   newLearning,
   whatWorkedToday,
   feedbackSubmittedForToday,
+  briefingRecommendation,
 }: TodayBriefingProps) {
   return (
     <Card className="border-primary/15 bg-primary/[0.03]">
@@ -48,15 +50,11 @@ export default function TodayBriefing({
         </p>
       </CardHeader>
       <CardContent className="space-y-6">
-        <section className="space-y-2">
-          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">What should I do today?</h2>
-          <p className="text-2xl font-semibold text-foreground">{scoreCard.recommended_action.title}</p>
-          <p className="text-sm leading-6 text-muted-foreground">{scoreCard.recommended_action.detail}</p>
-          <RecommendationFeedback
-            recommendedActionKey={scoreCard.recommended_action.driver}
-            feedbackSubmittedForToday={feedbackSubmittedForToday}
-          />
-        </section>
+        <BriefingRecommendationSection
+          recommendation={briefingRecommendation}
+          legacyAction={scoreCard.recommended_action}
+          feedbackSubmittedForToday={feedbackSubmittedForToday}
+        />
 
         <section className="space-y-2">
           <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">Why this is showing up</h2>

--- a/frontend/lib/__tests__/types.test.ts
+++ b/frontend/lib/__tests__/types.test.ts
@@ -48,4 +48,8 @@ describe("API types", () => {
     expectTypeOf<InsightBundle>().toHaveProperty("recovery_feedback");
     expectTypeOf<InsightBundle>().toHaveProperty("dismissed_components");
   });
+
+  it("InsightBundle exposes briefing_recommendation", () => {
+    expectTypeOf<InsightBundle>().toHaveProperty("briefing_recommendation");
+  });
 });

--- a/frontend/lib/__tests__/validators.test.ts
+++ b/frontend/lib/__tests__/validators.test.ts
@@ -37,5 +37,74 @@ describe("parseInsightBundle", () => {
       confirmed_recovery_levers: [],
       experiments: [],
     });
+    expect(bundle.briefing_recommendation).toBeNull();
+  });
+
+  it("parses a briefing recommendation when the payload includes one", () => {
+    const bundle = parseInsightBundle({
+      session_context: null,
+      patterns: [],
+      pattern_insights: [],
+      earned_pattern: null,
+      signature: null,
+      signature_narrative: "",
+      arc_narrative: "",
+      monthly_arc: null,
+      what_works: "",
+      recovery_feedback: [],
+      milestone: null,
+      check_in_count: 8,
+      accuracy_label: "Based on 8 real check-ins",
+      dismissed_components: [],
+      what_worked_today: null,
+      streak_milestones: [],
+      streak_forgiven: false,
+      personalization_progress: {
+        confirmed_triggers: 1,
+        confirmed_recovery_levers: 0,
+        experiments: 2,
+        confidence_trend: "up",
+      },
+      recommendation_basis: null,
+      briefing_change: null,
+      playbook: {
+        confirmed_triggers: [],
+        confirmed_recovery_levers: [],
+        experiments: [],
+      },
+      briefing_recommendation: {
+        headline: "Best move for tomorrow",
+        target_day: "tomorrow",
+        primary_action: {
+          key: "protect_focus_block",
+          title: "Protect a 90-minute focus block tomorrow morning",
+          detail: "Keep the first deep-work block clear.",
+          timeframe: "tomorrow",
+          kind: "trigger",
+          state: "confirmed",
+        },
+        fallback_action: {
+          key: "shutdown_on_time",
+          title: "End work by 6 PM tonight",
+          detail: "Use an earlier shutdown to reduce tomorrow's load.",
+          timeframe: "today",
+          kind: "recovery",
+          state: "emerging",
+        },
+        predicted_score_delta: 6,
+        risk_reduction_summary: "Reduces the chance of a crash day.",
+        why_this_action: "Meetings are your strongest confirmed trigger.",
+        why_now: "This is easiest to set up before tomorrow starts.",
+        confidence: "confirmed",
+        basis: {
+          kind: "trigger",
+          state: "confirmed",
+          summary: "Back-to-back meeting mornings are your strongest trigger.",
+          evidence_count: 4,
+        },
+      },
+    });
+
+    expect(bundle.briefing_recommendation?.primary_action.key).toBe("protect_focus_block");
   });
 });

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -19,6 +19,30 @@ export interface ScoreOutput {
 export type RecommendationState = "generic" | "observed" | "emerging" | "confirmed";
 export type PersonalizationKind = "trigger" | "recovery" | "experiment";
 
+export type RecommendationTargetDay = "today" | "tomorrow";
+
+export interface BriefingActionCandidate {
+  key: string;
+  title: string;
+  detail: string;
+  timeframe: RecommendationTargetDay;
+  kind: PersonalizationKind;
+  state: RecommendationState;
+}
+
+export interface BriefingRecommendation {
+  headline: string;
+  target_day: RecommendationTargetDay;
+  primary_action: BriefingActionCandidate;
+  fallback_action: BriefingActionCandidate | null;
+  predicted_score_delta: number;
+  risk_reduction_summary: string;
+  why_this_action: string;
+  why_now: string;
+  confidence: RecommendationState | "generic";
+  basis: RecommendationBasis | null;
+}
+
 export interface RecommendationBasis {
   kind: PersonalizationKind;
   state: RecommendationState;
@@ -261,6 +285,7 @@ export interface InsightBundle {
   recommendation_basis: RecommendationBasis | null;
   briefing_change: BriefingChange | null;
   playbook: PlaybookSections;
+  briefing_recommendation: BriefingRecommendation | null;
 }
 
 // NotificationPrefs matches handler.NotifPrefsResponse exactly.

--- a/frontend/lib/validators.ts
+++ b/frontend/lib/validators.ts
@@ -135,5 +135,8 @@ export const parseInsightBundle = (value: unknown): InsightBundle => {
     briefing_change: isRecord(bundle.briefing_change)
       ? (bundle.briefing_change as InsightBundle["briefing_change"])
       : null,
+    briefing_recommendation: isRecord(bundle.briefing_recommendation)
+      ? (bundle.briefing_recommendation as InsightBundle["briefing_recommendation"])
+      : null,
   } as InsightBundle;
 };


### PR DESCRIPTION
## Summary
- Add deterministic one-step recommender to insight payload
- Render new recommendation in TodayBriefing with primary action, fallback action, score-delta framing
- Preserve legacy recommended_action as compatibility fallback
- Backend: recommender.go with ranking, feasibility checks, driver-aware matching
- Frontend: types, validators, BriefingRecommendationSection component

## Test Plan
- Backend: go test ./internal/service/insight ./internal/api/handler - PASS
- Frontend: npm test -- lib/__tests__/types.test.ts lib/__tests__/validators.test.ts __tests__/today-briefing.test.tsx __tests__/dashboard-page.test.tsx - PASS
- Frontend: npm run build - PASS